### PR TITLE
Just inherit repeating documentation blocks

### DIFF
--- a/src/Admin/ChatsCommand.php
+++ b/src/Admin/ChatsCommand.php
@@ -22,54 +22,17 @@ use Longman\TelegramBot\Request;
  */
 class ChatsCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'chats';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'List all chats stored by the bot';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/chats';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
-
-    /**
-     * If this command needs mysql
-     *
-     * @var boolean
-     */
     protected $need_mysql = false;
+    /**#@-*/
 
     /**
      * Execution if MySQL is required but not available

--- a/src/Admin/SendtoallCommand.php
+++ b/src/Admin/SendtoallCommand.php
@@ -21,54 +21,17 @@ use Longman\TelegramBot\Request;
  */
 class SendtoallCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'sendtoall';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Send the message to all the user\'s bot';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/sendall <message to send>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.2.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
-
-    /**
-     * If this command needs mysql
-     *
-     * @var boolean
-     */
     protected $need_mysql = true;
+    /**#@-*/
 
     /**
      * Execution if MySQL is required but not available

--- a/src/Admin/SendtochannelCommand.php
+++ b/src/Admin/SendtochannelCommand.php
@@ -21,54 +21,17 @@ use Longman\TelegramBot\Request;
  */
 class SendtochannelCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'sendtochannel';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Send message to a channel';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/sendchannel <message to send>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '0.1.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
-
-    /**
-     * If this command needs mysql
-     *
-     * @var boolean
-     */
     protected $need_mysql = false;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/ChannelchatcreatedCommand.php
+++ b/src/Commands/ChannelchatcreatedCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class ChannelchatcreatedCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Channelchatcreated';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Channel chat created';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/ChoseninlineresultCommand.php
+++ b/src/Commands/ChoseninlineresultCommand.php
@@ -21,47 +21,16 @@ use Longman\TelegramBot\Request;
  */
 class ChoseninlineresultCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'choseninlineresult';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Chosen result query';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = false;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/DateCommand.php
+++ b/src/Commands/DateCommand.php
@@ -20,47 +20,16 @@ use Longman\TelegramBot\Request;
  */
 class DateCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'date';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Show date/time by location';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/date <location>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.2.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
+    /**#@-*/
 
     /**
      * Base URL for Google Maps API

--- a/src/Commands/DeletechatphotoCommand.php
+++ b/src/Commands/DeletechatphotoCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class DeletechatphotoCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Deletechatphoto';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Delete chat photo';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/EchoCommand.php
+++ b/src/Commands/EchoCommand.php
@@ -19,47 +19,16 @@ use Longman\TelegramBot\Request;
  */
 class EchoCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'echo';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Show text';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/echo <text>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/GenericCommand.php
+++ b/src/Commands/GenericCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class GenericCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Generic';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Handles generic commands or is executed by default when a command is not found';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/GenericmessageCommand.php
+++ b/src/Commands/GenericmessageCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class GenericmessageCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Genericmessage';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Handle generic message';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/GroupchatcreatedCommand.php
+++ b/src/Commands/GroupchatcreatedCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class GroupchatcreatedCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Groupchatcreated';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Group chat created';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -19,47 +19,16 @@ use Longman\TelegramBot\Request;
  */
 class HelpCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'help';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Show bot commands help';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/help or /help <command>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/InlinequeryCommand.php
+++ b/src/Commands/InlinequeryCommand.php
@@ -21,47 +21,16 @@ use Longman\TelegramBot\Request;
  */
 class InlinequeryCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'inlinequery';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Reply to inline query';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = false;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/LeftchatparticipantCommand.php
+++ b/src/Commands/LeftchatparticipantCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class LeftchatparticipantCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'leftchatparticipant';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Left Chat Participant';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/NewchatparticipantCommand.php
+++ b/src/Commands/NewchatparticipantCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class NewchatparticipantCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Newchatparticipant';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'New Chat Participant';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/NewchattitleCommand.php
+++ b/src/Commands/NewchattitleCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class NewchattitleCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Newchattitle';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'New chat Title';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/SlapCommand.php
+++ b/src/Commands/SlapCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class SlapCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'slap';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Slap someone with their username';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/slap <@user>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -19,47 +19,16 @@ use Longman\TelegramBot\Request;
  */
 class StartCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'start';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Start command';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = false;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/SupergroupchatcreatedCommand.php
+++ b/src/Commands/SupergroupchatcreatedCommand.php
@@ -19,40 +19,15 @@ use Longman\TelegramBot\Request;
  */
 class SupergroupchatcreatedCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'Supergroupchatcreated';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Super group chat created';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
+    /**#@-*/
 
     /**
      * Execute command

--- a/src/Commands/WeatherCommand.php
+++ b/src/Commands/WeatherCommand.php
@@ -19,47 +19,16 @@ use Longman\TelegramBot\Request;
  */
 class WeatherCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'weather';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Show weather by location';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/weather <location>';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
+    /**#@-*/
 
     /**
      * Get weather using cURL request

--- a/src/Commands/WhoamiCommand.php
+++ b/src/Commands/WhoamiCommand.php
@@ -22,47 +22,16 @@ use Longman\TelegramBot\Request;
  */
 class WhoamiCommand extends Command
 {
-    /**
-     * Name
-     *
-     * @var string
+    /**#@+
+     * {@inheritdoc}
      */
     protected $name = 'whoami';
-
-    /**
-     * Description
-     *
-     * @var string
-     */
     protected $description = 'Show your id, name and username';
-
-    /**
-     * Usage
-     *
-     * @var string
-     */
     protected $usage = '/whoami';
-
-    /**
-     * Version
-     *
-     * @var string
-     */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
     protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
     protected $public = true;
+    /**#@-*/
 
     /**
      * Execute command


### PR DESCRIPTION
Instead of having to write the same docblocks over and over again for each command, just inherit them for the parent class!

Unfortunately, when generating the documentation, phpdoc gives a notice about not finding the documentation for the member variables, because at compilation time it's impossible to know if it can inherit the values.
That put aside, it's just SO much easier to read the code without tons of comments everywhere.