### PR TITLE
Remove any unnecessary code from commands.

### DIFF
--- a/src/Admin/ChatsCommand.php
+++ b/src/Admin/ChatsCommand.php
@@ -13,8 +13,6 @@ namespace Longman\TelegramBot\Commands;
 use Longman\TelegramBot\Command;
 use Longman\TelegramBot\DB;
 use Longman\TelegramBot\Entities\Chat;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 
 /**
@@ -51,13 +49,6 @@ class ChatsCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -81,12 +72,13 @@ class ChatsCommand extends Command
         //Preparing message
         $message = $this->getMessage();
         $chat_id = $message->getChat()->getId();
+
         $data = [
             'chat_id' => $chat_id,
             'text'    => 'Sorry no database connection, unable to execute "' . $this->name . '" command.',
         ];
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+
+        return Request::sendMessage($data)->isOk();
     }
 
     /**
@@ -96,12 +88,9 @@ class ChatsCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
-        $message_id = $message->getMessageId();
-        $text = $message->getText(true);
 
         $results = DB::selectChats(
             true, //Send to groups (group chat)
@@ -133,7 +122,7 @@ class ChatsCommand extends Command
             }
         }
 
-        if (($user_chats + $group_chats + $super_group_chats) == 0) {
+        if (($user_chats + $group_chats + $super_group_chats) === 0) {
             $text = 'No chats found..';
         } else {
             $text .= "\n" . 'Private Chats: ' . $user_chats;
@@ -146,7 +135,7 @@ class ChatsCommand extends Command
             'chat_id' => $chat_id,
             'text'    => $text,
         ];
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Admin/SendtoallCommand.php
+++ b/src/Admin/SendtoallCommand.php
@@ -11,9 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\DB;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 
 /**
@@ -50,13 +47,6 @@ class SendtoallCommand extends Command
     protected $version = '1.2.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -80,12 +70,13 @@ class SendtoallCommand extends Command
         //Preparing message
         $message = $this->getMessage();
         $chat_id = $message->getChat()->getId();
+
         $data = [
             'chat_id' => $chat_id,
             'text'    => 'Sorry no database connection, unable to execute "' . $this->name . '" command.',
         ];
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+
+        return Request::sendMessage($data)->isOk();
     }
 
     /**
@@ -97,12 +88,9 @@ class SendtoallCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
-        $message_id = $message->getMessageId();
-        $text = $message->getText(true);
 
         if (empty($text)) {
             $text = 'Write the message to send: /sendall <message>';
@@ -147,7 +135,7 @@ class SendtoallCommand extends Command
             }
             $text .= 'Delivered: ' . ($tot - $fail) . '/' . $tot . "\n";
         }
-        if ($tot == 0) {
+        if ($tot === 0) {
             $text = 'No users or chats found..';
         }
 
@@ -156,7 +144,6 @@ class SendtoallCommand extends Command
             'text'    => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Admin/SendtochannelCommand.php
+++ b/src/Admin/SendtochannelCommand.php
@@ -11,9 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\DB;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 
 /**
@@ -50,13 +47,6 @@ class SendtochannelCommand extends Command
     protected $version = '0.1.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -79,11 +69,9 @@ class SendtochannelCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
-        $message_id = $message->getMessageId();
         $text = $message->getText(true);
 
         if (empty($text)) {
@@ -109,7 +97,6 @@ class SendtochannelCommand extends Command
             'text'    => $text_back,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/ChannelchatcreatedCommand.php
+++ b/src/Commands/ChannelchatcreatedCommand.php
@@ -48,7 +48,7 @@ class ChannelchatcreatedCommand extends Command
         //$message = $this->getMessage();
         //$channel_chat_created = $message->getChannelChatCreated();
 
-         //System command, do nothing
+        //System command, do nothing
         return true;
     }
 }

--- a/src/Commands/ChannelchatcreatedCommand.php
+++ b/src/Commands/ChannelchatcreatedCommand.php
@@ -11,8 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * Channel chat created command

--- a/src/Commands/ChannelchatcreatedCommand.php
+++ b/src/Commands/ChannelchatcreatedCommand.php
@@ -34,25 +34,11 @@ class ChannelchatcreatedCommand extends Command
     protected $description = 'Channel chat created';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,12 +47,10 @@ class ChannelchatcreatedCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $message = $this->getMessage();
+        //$message = $this->getMessage();
+        //$channel_chat_created = $message->getChannelChatCreated();
 
-        $channel_chat_created = $message->getChannelChatCreated();
-
-        //Temporary, do nothing
-        return 1;
+         //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/ChoseninlineresultCommand.php
+++ b/src/Commands/ChoseninlineresultCommand.php
@@ -36,32 +36,11 @@ class ChoseninlineresultCommand extends Command
     protected $description = 'Chosen result query';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
-    protected $public = false;
 
     /**
      * Execute command
@@ -70,13 +49,12 @@ class ChoseninlineresultCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $inline_query = $update->getChosenInlineResult();
-        $query = $inline_query->getQuery();
-
         //Information about chosen result is returned
-        //Do nothing
+        //$update = $this->getUpdate();
+        //$inline_query = $update->getChosenInlineResult();
+        //$query = $inline_query->getQuery();
 
-        return 1;
+        //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/ChoseninlineresultCommand.php
+++ b/src/Commands/ChoseninlineresultCommand.php
@@ -11,10 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Entity;
-use Longman\TelegramBot\Entities\InlineQueryResultArticle;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * Chosen inline result command

--- a/src/Commands/DateCommand.php
+++ b/src/Commands/DateCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 

--- a/src/Commands/DateCommand.php
+++ b/src/Commands/DateCommand.php
@@ -49,13 +49,6 @@ class DateCommand extends Command
     protected $version = '1.2.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -214,7 +207,6 @@ class DateCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
@@ -238,7 +230,6 @@ class DateCommand extends Command
             'text'                => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/DateCommand.php
+++ b/src/Commands/DateCommand.php
@@ -127,7 +127,7 @@ class DateCommand extends Command
 
         $google_api_key = $this->getConfig('google_api_key');
         if (!empty($google_api_key)) {
-            $params.= '&key=' . $google_api_key;
+            $params .= '&key=' . $google_api_key;
         }
 
         $data = $this->request($url . $params);

--- a/src/Commands/DeletechatphotoCommand.php
+++ b/src/Commands/DeletechatphotoCommand.php
@@ -34,25 +34,11 @@ class DeletechatphotoCommand extends Command
     protected $description = 'Delete chat photo';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,12 +47,10 @@ class DeletechatphotoCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $message = $this->getMessage();
+        //$message = $this->getMessage();
+        //$delete_chat_photo = $message->getDeleteChatPhoto();
 
-        $delete_chat_photo = $message->getDeleteChatPhoto();
-
-        //Temporary, do nothing
-        return 1;
+        //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/DeletechatphotoCommand.php
+++ b/src/Commands/DeletechatphotoCommand.php
@@ -11,8 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * Delete chat photo command

--- a/src/Commands/EchoCommand.php
+++ b/src/Commands/EchoCommand.php
@@ -48,13 +48,6 @@ class EchoCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -68,9 +61,7 @@ class EchoCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
-
         $chat_id = $message->getChat()->getId();
         $text = $message->getText(true);
 
@@ -79,7 +70,6 @@ class EchoCommand extends Command
             'text'    => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/EchoCommand.php
+++ b/src/Commands/EchoCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/GenericCommand.php
+++ b/src/Commands/GenericCommand.php
@@ -34,25 +34,11 @@ class GenericCommand extends Command
     protected $description = 'Handles generic commands or is executed by default when a command is not found';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -63,22 +49,17 @@ class GenericCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
-        $chat_id = $message->getChat()->getId();
 
         //You can use $command as param
         $command = $message->getCommand();
-
         $chat_id = $message->getChat()->getId();
-        $text = $message->getText(true);
 
         $data = [
             'chat_id' => $chat_id,
             'text'    => 'Command: ' . $command . ' not found.. :(',
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/GenericCommand.php
+++ b/src/Commands/GenericCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/GenericmessageCommand.php
+++ b/src/Commands/GenericmessageCommand.php
@@ -34,25 +34,11 @@ class GenericmessageCommand extends Command
     protected $description = 'Handle generic message';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,17 +47,7 @@ class GenericmessageCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $message = $this->getMessage();
-        $chat_id = $message->getChat()->getId();
-
-        //You can use $command as param
-        $command = $message->getCommand();
-
-        $chat_id = $message->getChat()->getId();
-        $text = $message->getText(true);
-
-        //Do nothing
-        return 1;
+        //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/GenericmessageCommand.php
+++ b/src/Commands/GenericmessageCommand.php
@@ -11,8 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * Generic message command

--- a/src/Commands/GroupchatcreatedCommand.php
+++ b/src/Commands/GroupchatcreatedCommand.php
@@ -11,8 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * Group chat created command

--- a/src/Commands/GroupchatcreatedCommand.php
+++ b/src/Commands/GroupchatcreatedCommand.php
@@ -34,25 +34,11 @@ class GroupchatcreatedCommand extends Command
     protected $description = 'Group chat created';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,12 +47,10 @@ class GroupchatcreatedCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $message = $this->getMessage();
+        //$message = $this->getMessage();
+        //$group_chat_created = $message->getGroupChatCreated();
 
-        $group_chat_created = $message->getGroupChatCreated();
-
-        //Temporary, do nothing
-        return 1;
+        //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -48,13 +48,6 @@ class HelpCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -68,7 +61,6 @@ class HelpCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
@@ -116,7 +108,6 @@ class HelpCommand extends Command
             'text'                => $msg,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/InlinequeryCommand.php
+++ b/src/Commands/InlinequeryCommand.php
@@ -11,9 +11,7 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Entity;
 use Longman\TelegramBot\Entities\InlineQueryResultArticle;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/InlinequeryCommand.php
+++ b/src/Commands/InlinequeryCommand.php
@@ -36,32 +36,11 @@ class InlinequeryCommand extends Command
     protected $description = 'Reply to inline query';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
-    protected $public = false;
 
     /**
      * Execute command
@@ -86,10 +65,8 @@ class InlinequeryCommand extends Command
         foreach ($articles as $article) {
             $array_article[] = new InlineQueryResultArticle($article);
         }
-        $array_json = '['.implode(',', $array_article).']';
-        $data['results'] = $array_json;
+        $data['results'] = '[' . implode(',', $array_article) . ']';
 
-        $result = Request::answerInlineQuery($data);
-        return $result->isOk();
+        return Request::answerInlineQuery($data)->isOk();
     }
 }

--- a/src/Commands/InlinequeryCommand.php
+++ b/src/Commands/InlinequeryCommand.php
@@ -54,9 +54,9 @@ class InlinequeryCommand extends Command
         $data = ['inline_query_id' => $inline_query->getId()];
 
         $articles = [
-            ['id' => '001' , 'title' => 'https://core.telegram.org/bots/api#answerinlinequery', 'message_text' => 'you enter: ' . $query ],
-            ['id' => '002' , 'title' => 'https://core.telegram.org/bots/api#answerinlinequery', 'message_text' => 'you enter: ' . $query ],
-            ['id' => '003' , 'title' => 'https://core.telegram.org/bots/api#answerinlinequery', 'message_text' => 'you enter: ' . $query ],
+            ['id' => '001', 'title' => 'https://core.telegram.org/bots/api#answerinlinequery', 'message_text' => 'you enter: ' . $query],
+            ['id' => '002', 'title' => 'https://core.telegram.org/bots/api#answerinlinequery', 'message_text' => 'you enter: ' . $query],
+            ['id' => '003', 'title' => 'https://core.telegram.org/bots/api#answerinlinequery', 'message_text' => 'you enter: ' . $query],
         ];
 
         $array_article = [];

--- a/src/Commands/LeftchatparticipantCommand.php
+++ b/src/Commands/LeftchatparticipantCommand.php
@@ -11,8 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * Left chat participant command

--- a/src/Commands/LeftchatparticipantCommand.php
+++ b/src/Commands/LeftchatparticipantCommand.php
@@ -34,25 +34,11 @@ class LeftchatparticipantCommand extends Command
     protected $description = 'Left Chat Participant';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,12 +47,10 @@ class LeftchatparticipantCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $message = $this->getMessage();
+        //$message = $this->getMessage();
+        //$participant = $message->getLeftChatParticipant();
 
-        $participant = $message->getLeftChatParticipant();
-
-        //Temporary, do nothing
-        return 1;
+        //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/NewchatparticipantCommand.php
+++ b/src/Commands/NewchatparticipantCommand.php
@@ -34,25 +34,11 @@ class NewchatparticipantCommand extends Command
     protected $description = 'New Chat Participant';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,16 +47,15 @@ class NewchatparticipantCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
         $participant = $message->getNewChatParticipant();
 
-        if (strtolower($participant->getUsername()) == strtolower($this->getTelegram()->getBotName())) {
+        if (strtolower($participant->getUsername()) === strtolower($this->getTelegram()->getBotName())) {
             $text = 'Hi there!';
         } else {
-            $text = 'Hi ' . $participant->tryMention() . ' !';
+            $text = 'Hi ' . $participant->tryMention() . '!';
         }
 
         $data = [
@@ -78,7 +63,6 @@ class NewchatparticipantCommand extends Command
             'text'    => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/NewchatparticipantCommand.php
+++ b/src/Commands/NewchatparticipantCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/NewchattitleCommand.php
+++ b/src/Commands/NewchattitleCommand.php
@@ -34,25 +34,11 @@ class NewchattitleCommand extends Command
     protected $description = 'New chat Title';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
      */
     protected $version = '1.0.0';
-
-    /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
 
     /**
      * Execute command
@@ -61,12 +47,10 @@ class NewchattitleCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
-        $message = $this->getMessage();
+        //$message = $this->getMessage();
+        //$new_chat_title = $message->getNewChatTitle();
 
-        $new_chat_title = $message->getNewChatTitle();
-
-        //Temporary, do nothing
-        return 1;
+        //System command, do nothing
+        return true;
     }
 }

--- a/src/Commands/NewchattitleCommand.php
+++ b/src/Commands/NewchattitleCommand.php
@@ -11,8 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
-use Longman\TelegramBot\Request;
 
 /**
  * New chat title command

--- a/src/Commands/SlapCommand.php
+++ b/src/Commands/SlapCommand.php
@@ -48,21 +48,14 @@ class SlapCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * Execute command
      *
      * @return boolean
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
+
         $chat_id = $message->getChat()->getId();
         $message_id = $message->getMessageId();
         $text = $message->getText(true);
@@ -82,7 +75,6 @@ class SlapCommand extends Command
             'text'    => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/SlapCommand.php
+++ b/src/Commands/SlapCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -48,27 +48,12 @@ class StartCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
-     * If this command is public
-     *
-     * @var boolean
-     */
-    protected $public = false;
-
-    /**
      * Execute command
      *
      * @return boolean
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
@@ -79,7 +64,6 @@ class StartCommand extends Command
             'text'    => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/SupergroupchatcreatedCommand.php
+++ b/src/Commands/SupergroupchatcreatedCommand.php
@@ -34,13 +34,6 @@ class SupergroupchatcreatedCommand extends Command
     protected $description = 'Super group chat created';
 
     /**
-     * Usage
-     *
-     * @var string
-     */
-    protected $usage = '/';
-
-    /**
      * Version
      *
      * @var string
@@ -48,23 +41,15 @@ class SupergroupchatcreatedCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * Execute command
-     *
-     * @todo $chat_id isn't defined!
      *
      * @return boolean
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
+
+        $chat_id = $message->getChat()->getId();
         $text = '';
 
         if ($message->getSuperGroupChatCreated()) {
@@ -77,7 +62,6 @@ class SupergroupchatcreatedCommand extends Command
             'text'    => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/SupergroupchatcreatedCommand.php
+++ b/src/Commands/SupergroupchatcreatedCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/WeatherCommand.php
+++ b/src/Commands/WeatherCommand.php
@@ -48,13 +48,6 @@ class WeatherCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -156,7 +149,6 @@ class WeatherCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $chat_id = $message->getChat()->getId();
@@ -180,7 +172,6 @@ class WeatherCommand extends Command
             'text'                => $text,
         ];
 
-        $result = Request::sendMessage($data);
-        return $result->isOk();
+        return Request::sendMessage($data)->isOk();
     }
 }

--- a/src/Commands/WeatherCommand.php
+++ b/src/Commands/WeatherCommand.php
@@ -117,19 +117,19 @@ class WeatherCommand extends Command
 
             switch (strtolower($decode['weather'][0]['main'])) {
                 case 'clear':
-                    $conditions.= ' ☀';
+                    $conditions .= ' ☀';
                     break;
 
                 case 'clouds':
-                    $conditions.= ' ☁☁';
+                    $conditions .= ' ☁☁';
                     break;
 
                 case 'rain':
-                    $conditions.= ' ☔';
+                    $conditions .= ' ☔';
                     break;
 
                 case 'thunderstorm':
-                    $conditions.= ' ☔☔☔☔';
+                    $conditions .= ' ☔☔☔☔';
                     break;
             }
 

--- a/src/Commands/WeatherCommand.php
+++ b/src/Commands/WeatherCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/WhoamiCommand.php
+++ b/src/Commands/WhoamiCommand.php
@@ -14,7 +14,6 @@ namespace Longman\TelegramBot\Commands;
 
 use Longman\TelegramBot\Command;
 use Longman\TelegramBot\Entities\File;
-use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 
 /**

--- a/src/Commands/WhoamiCommand.php
+++ b/src/Commands/WhoamiCommand.php
@@ -75,7 +75,7 @@ class WhoamiCommand extends Command
 
         $caption = 'Your Id: ' . $user_id . "\n";
         $caption .= 'Name: ' . $message->getFrom()->getFirstName()
-             . ' ' . $message->getFrom()->getLastName() . "\n";
+        . ' ' . $message->getFrom()->getLastName() . "\n";
         $caption .= 'Username: ' . $message->getFrom()->getUsername();
 
         //Fetch user profile photo

--- a/src/Commands/WhoamiCommand.php
+++ b/src/Commands/WhoamiCommand.php
@@ -51,13 +51,6 @@ class WhoamiCommand extends Command
     protected $version = '1.0.0';
 
     /**
-     * If this command is enabled
-     *
-     * @var boolean
-     */
-    protected $enabled = true;
-
-    /**
      * If this command is public
      *
      * @var boolean
@@ -71,7 +64,6 @@ class WhoamiCommand extends Command
      */
     public function execute()
     {
-        $update = $this->getUpdate();
         $message = $this->getMessage();
 
         $user_id = $message->getFrom()->getId();
@@ -82,7 +74,7 @@ class WhoamiCommand extends Command
         //Send chat action
         Request::sendChatAction(['chat_id' => $chat_id, 'action' => 'typing']);
 
-        $caption = 'Your Id: ' . $message->getFrom()->getId() . "\n";
+        $caption = 'Your Id: ' . $user_id . "\n";
         $caption .= 'Name: ' . $message->getFrom()->getFirstName()
              . ' ' . $message->getFrom()->getLastName() . "\n";
         $caption .= 'Username: ' . $message->getFrom()->getUsername();


### PR DESCRIPTION
Changes include:
- Removed the definitions of member variables that had the same values as their inherited defaults. These can be removed since the default values apply anyway.
- Removed superfluous code form execute command.

Fixed #86 in the process