### PR TITLE
fix Exception Log

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,11 @@ $telegram->setUploadPath('yourpath/Upload');
 ```
 
 ### Logging
+Thrown Exceptions are not stored by default. You can Enable this feature adding this line in your 'webhook.php' or 'getUpdates.php'
 
-Thrown Exceptions are stored in *TelegramException.log* file (in the base directory).
+```php
+    Longman\TelegramBot\Logger::initialize('your_path/TelegramException.log');
+```
 
 Incoming update (json string from webhook and getUpdates) can be logged in a text file. Set those options with the methods:
 ```php

--- a/src/Exception/TelegramException.php
+++ b/src/Exception/TelegramException.php
@@ -10,6 +10,8 @@
 
 namespace Longman\TelegramBot\Exception;
 
+use Longman\TelegramBot\Logger;
+
 /**
  * Main exception class used for exception handling
  */
@@ -24,12 +26,6 @@ class TelegramException extends \Exception
     public function __construct($message, $code = 0)
     {
         parent::__construct($message, $code);
-
-        $path = 'TelegramException.log';
-        $status = file_put_contents(
-            $path,
-            date('Y-m-d H:i:s', time()) . ' ' . self::__toString() . "\n",
-            FILE_APPEND
-        );
+        Logger::logException(self::__toString());
     }
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot;
+
+/**
+ * Class Logger.
+ */
+class Logger
+{
+    /**
+     * Exception log path
+     *
+     * @var string
+     */
+    static protected $exception_log_path = null;
+
+    /**
+     * Initialize
+     *
+     * @param string $exception_log_path
+     */
+    public static function initialize($exception_log_path)
+    {
+        self::$exception_log_path = $exception_log_path;
+    }
+
+    /**
+     * Log exception
+     *
+     * @param string $text
+     *
+     * @return bool
+     */
+    public static function logException($text)
+    {
+        if (!is_null(self::$exception_log_path)) {
+            return file_put_contents(
+                self::$exception_log_path,
+                date('Y-m-d H:i:s', time()) . ' ' . $text . "\n",
+                FILE_APPEND
+            );
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
I introduced the logger Class https://github.com/akalongman/php-telegram-bot/issues/106 to Handle the path of the exception logs.
Don't want to rewrite log system now just path this bug https://github.com/akalongman/php-telegram-bot/issues/96 .
Exception are not stored by default, you can start log then adding:
```
Longman\TelegramBot\Logger::initialize('Exceptionlog.log');
```
in your webhook.php or in your getUpdates.php