### PR TITLE
Add new_chat_photo command

### DIFF
--- a/src/Commands/SystemCommands/NewchatphotoCommand.php
+++ b/src/Commands/SystemCommands/NewchatphotoCommand.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\SystemCommands;
+
+use Longman\TelegramBot\Commands\SystemCommand;
+
+/**
+ * New chat photo command
+ */
+class NewchatphotoCommand extends SystemCommand
+{
+    /**#@+
+     * {@inheritdoc}
+     */
+    protected $name = 'Newchatphoto';
+    protected $description = 'New chat Photo';
+    protected $version = '1.0.1';
+    /**#@-*/
+
+    /**
+     * {@inheritdoc}
+     */
+    /*public function execute()
+    {
+        //$message = $this->getMessage();
+        //$new_chat_photo = $message->getNewChatPhoto();
+    }*/
+}

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -205,6 +205,7 @@ class Message extends Entity
                 }
             }
             $this->new_chat_photo = $photos;
+            $this->type = 'new_chat_photo';
         }
 
         $this->delete_chat_photo = isset($data['delete_chat_photo']) ? $data['delete_chat_photo'] : null;

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -457,6 +457,7 @@ class Telegram
                 'left_chat_participant',
                 'new_chat_participant',
                 'new_chat_title',
+                'new_chat_photo',
                 'supergroup_chat_created',
             ])) {
                 $command = $this->getCommandFromType($type);

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -456,8 +456,8 @@ class Telegram
                 'group_chat_created',
                 'left_chat_participant',
                 'new_chat_participant',
-                'new_chat_title',
                 'new_chat_photo',
+                'new_chat_title',
                 'supergroup_chat_created',
             ])) {
                 $command = $this->getCommandFromType($type);


### PR DESCRIPTION
Noticed this hasn't been added yet, I know this can be handled by genericmessage but having comands for each message type might be a good idea.