### PR TITLE
Add migrate_to_chat_id and migrate_from_chat_id commands

### DIFF
--- a/src/Commands/SystemCommands/MigratefromchatidCommand.php
+++ b/src/Commands/SystemCommands/MigratefromchatidCommand.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\SystemCommands;
+
+use Longman\TelegramBot\Commands\SystemCommand;
+
+/**
+ * Migrate from chat id command
+ */
+class MigratefromchatidCommand extends SystemCommand
+{
+    /**#@+
+     * {@inheritdoc}
+     */
+    protected $name = 'Migratefromchatid';
+    protected $description = 'Migrate from chat id';
+    protected $version = '1.0.1';
+    /**#@-*/
+
+    /**
+     * {@inheritdoc}
+     */
+    /*public function execute()
+    {
+        //$message = $this->getMessage();
+        //$migrate_from_chat_id = $message->getMigrateFromChatId();
+    }*/
+}

--- a/src/Commands/SystemCommands/MigratetochatidCommand.php
+++ b/src/Commands/SystemCommands/MigratetochatidCommand.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\SystemCommands;
+
+use Longman\TelegramBot\Commands\SystemCommand;
+
+/**
+ * Migrate to chat id command
+ */
+class MigratetochatidCommand extends SystemCommand
+{
+    /**#@+
+     * {@inheritdoc}
+     */
+    protected $name = 'Migratetochatid';
+    protected $description = 'Migrate to chat id';
+    protected $version = '1.0.1';
+    /**#@-*/
+
+    /**
+     * {@inheritdoc}
+     */
+    /*public function execute()
+    {
+        //$message = $this->getMessage();
+        //$migrate_to_chat_id = $message->getMigrateToChatId();
+    }*/
+}

--- a/src/Commands/SystemCommands/SupergroupchatcreatedCommand.php
+++ b/src/Commands/SystemCommands/SupergroupchatcreatedCommand.php
@@ -29,23 +29,9 @@ class SupergroupchatcreatedCommand extends SystemCommand
     /**
      * {@inheritdoc}
      */
-    public function execute()
+    /*public function execute()
     {
-        $message = $this->getMessage();
-
-        $chat_id = $message->getChat()->getId();
-        $text = '';
-
-        if ($message->getSuperGroupChatCreated()) {
-            $text = 'Your group has become a Supergroup!' . "\n";
-            $text .= 'Chat id has changed from ' . $message->getMigrateFromChatId() . ' to ' . $message->getMigrateToChatId();
-        }
-
-        $data = [
-            'chat_id' => $chat_id,
-            'text'    => $text,
-        ];
-
-        return Request::sendMessage($data);
-    }
+        //$message = $this->getMessage();
+        //$supergroup_chat_created = $message->getSuperGroupChatCreated();
+    }*/
 }

--- a/src/Commands/SystemCommands/SupergroupchatcreatedCommand.php
+++ b/src/Commands/SystemCommands/SupergroupchatcreatedCommand.php
@@ -11,7 +11,6 @@
 namespace Longman\TelegramBot\Commands\SystemCommands;
 
 use Longman\TelegramBot\Commands\SystemCommand;
-use Longman\TelegramBot\Request;
 
 /**
  * Super group chat created command

--- a/src/DB.php
+++ b/src/DB.php
@@ -472,6 +472,7 @@ class DB
         $left_chat_participant = $message->getLeftChatParticipant();
 
         $migrate_from_chat_id = $message->getMigrateFromChatId();
+        $migrate_to_chat_id = $message->getMigrateToChatId();
 
         try {
             //chat table
@@ -488,11 +489,22 @@ class DB
             $chat_title = $chat->getTitle();
             $type = $chat->getType();
 
-            $sth2->bindParam(':id', $chat_id, \PDO::PARAM_INT);
+            if ($migrate_to_chat_id) {
+
+                $type = 'supergroup';
+
+                $sth2->bindParam(':id', $migrate_to_chat_id, \PDO::PARAM_INT);
+                $sth2->bindParam(':oldid', $chat_id, \PDO::PARAM_INT);
+
+            } else {
+
+                $sth2->bindParam(':id', $chat_id, \PDO::PARAM_INT);
+                $sth2->bindParam(':oldid', $migrate_to_chat_id, \PDO::PARAM_INT);
+            }
+
             $sth2->bindParam(':type', $type, \PDO::PARAM_INT);
             $sth2->bindParam(':title', $chat_title, \PDO::PARAM_STR, 255);
             $sth2->bindParam(':date', $date, \PDO::PARAM_STR);
-            $sth2->bindParam(':oldid', $migrate_from_chat_id, \PDO::PARAM_INT);
 
             $status = $sth2->execute();
 
@@ -509,7 +521,7 @@ class DB
             self::insertUser($forward_from, $forward_date);
             $forward_from = $forward_from->getId();
         }
-        
+
         if ($new_chat_participant) {
             //Insert the new chat user
             self::insertUser($new_chat_participant, $date, $chat);
@@ -569,6 +581,7 @@ class DB
             $supergroup_chat_created = $message->getSupergroupChatCreated();
             $channel_chat_created = $message->getChannelChatCreated();
             $migrate_from_chat_id = $message->getMigrateFromChatId();
+            $migrate_to_chat_id = $message->getMigrateToChatId();
 
             $sth->bindParam(':message_id', $message_id, \PDO::PARAM_INT);
             $sth->bindParam(':user_id', $from_id, \PDO::PARAM_INT);
@@ -618,10 +631,10 @@ class DB
             $sth->bindParam(':new_chat_photo', $new_chat_photo, \PDO::PARAM_STR);
             $sth->bindParam(':delete_chat_photo', $delete_chat_photo, \PDO::PARAM_STR);
             $sth->bindParam(':group_chat_created', $group_chat_created, \PDO::PARAM_STR);
-            $sth->bindParam(':supergroup_chat_created', $migrate_from_chat_id, \PDO::PARAM_INT);
-            $sth->bindParam(':channel_chat_created', $supergroup_chat_created, \PDO::PARAM_INT);
-            $sth->bindParam(':migrate_from_chat_id', $channel_chat_created, \PDO::PARAM_INT);
-            $sth->bindParam(':migrate_to_chat_id', $migrate_from_chat_id, \PDO::PARAM_INT);
+            $sth->bindParam(':supergroup_chat_created', $supergroup_chat_created, \PDO::PARAM_INT);
+            $sth->bindParam(':channel_chat_created', $channel_chat_created, \PDO::PARAM_INT);
+            $sth->bindParam(':migrate_from_chat_id', $migrate_from_chat_id, \PDO::PARAM_INT);
+            $sth->bindParam(':migrate_to_chat_id', $migrate_to_chat_id, \PDO::PARAM_INT);
             $status = $sth->execute();
 
         } catch (PDOException $e) {

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -228,7 +228,13 @@ class Message extends Entity
         }
 
         $this->migrate_to_chat_id = isset($data['migrate_to_chat_id']) ? $data['migrate_to_chat_id'] : null;
+        if ($this->migrate_to_chat_id) {
+            $this->type = 'migrate_to_chat_id';
+        }
         $this->migrate_from_chat_id = isset($data['migrate_from_chat_id']) ? $data['migrate_from_chat_id'] : null;
+        if ($this->migrate_from_chat_id) {
+            $this->type = 'migrate_from_chat_id';
+        }
 
     }
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -455,6 +455,8 @@ class Telegram
                 'delete_chat_photo',
                 'group_chat_created',
                 'left_chat_participant',
+                'migrate_from_chat_id',
+                'migrate_to_chat_id',
                 'new_chat_participant',
                 'new_chat_title',
                 'supergroup_chat_created',


### PR DESCRIPTION
Code in **SupergroupchatcreatedCommand.php** will never run as intended, **supergroup_chat_created** works just like **group_chat_created**, **migrate_to_chat_id** and **migrate_from_chat_id** are sent seperately.

Placing code from **SupergroupchatcreatedCommand.php** into **MigratetochatidCommand.php** and editing it a bit will also don't work, bot can't message new group id answering to update from old group id. (tried to figure it out and it just doesn't work)

Also **migrate_from_chat_id** is not always sent to bot.