### PR TITLE
Improved 'chats' command

### DIFF
--- a/src/Commands/AdminCommands/ChatsCommand.php
+++ b/src/Commands/AdminCommands/ChatsCommand.php
@@ -52,9 +52,9 @@ class ChatsCommand extends AdminCommand
         $group_chats = 0;
         $super_group_chats = 0;
 
-        if($text === '') {
+        if ($text === '') {
             $text_back = '';
-        } else if ($text == '*') {
+        } elseif ($text == '*') {
             $text_back = 'List of all bot chats:' . "\n";
         } else {
             $text_back = 'Chat search results:' . "\n";
@@ -66,19 +66,19 @@ class ChatsCommand extends AdminCommand
             $chat = new Chat($result);
 
             if ($chat->isPrivateChat() && ($text === '' || $text == '*' || strpos(strtolower($chat->tryMention()), strtolower($text)) !== false || strpos(strtolower($chat->getFirstName()), strtolower($text)) !== false || strpos(strtolower($chat->getLastName()), strtolower($text)) !== false)) {
-                if($text != '') {
+                if ($text != '') {
                     $text_back .= '- P ' . $chat->tryMention() . ' (' . $chat->getId() . ')' . "\n";
                 }
 
                 ++$user_chats;
             } elseif ($chat->isSuperGroup() && ($text === '' || $text == '*' || strpos(strtolower($chat->tryMention()), strtolower($text)) !== false)) {
-                if($text != '') {
+                if ($text != '') {
                     $text_back .= '- S ' . $chat->getTitle() . ' (' . $chat->getId() . ')' . "\n";
                 }
 
                 ++$super_group_chats;
             } elseif ($chat->isGroupChat() && ($text === '' || $text == '*' || strpos(strtolower($chat->tryMention()), strtolower($text)) !== false)) {
-                if($text != '') {
+                if ($text != '') {
                     $text_back .= '- G ' . $chat->getTitle() . ' (' . $chat->getId() . ')' . "\n";
                 }
 


### PR DESCRIPTION
List of changes done:
-all chats are no longer printed by default
-added search by group/user name and also user's first/last name
-chat id will be also shown
-fixed an issue where super groups were listed as normal groups

Showing all chats by default isn't good idea considering someone can have like ~1000 entries in DB, it will take some time and can prevent bot from answering to requests from other people, not to mention the message spam in the conversation.

