### PR TITLE
Throw on invalid responses

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -317,8 +317,13 @@ class Request
             return new ServerResponse($fake_response, $bot_name);
         }
 
-        $response = self::executeCurl($action, $data);
-        return new ServerResponse(json_decode($response, true), $bot_name);
+        $response = json_decode(self::executeCurl($action, $data), true);
+
+        if (is_null($response)) {
+            throw new TelegramException('Telegram returned an invalid response! Please your bot name and api token.');
+        }
+
+        return new ServerResponse($response, $bot_name);
     }
 
     /**


### PR DESCRIPTION
If you send something inexistent to Telegram it will return an HTML 302 response. So now people should be able catch those exceptions:

![image](https://cloud.githubusercontent.com/assets/3182864/14483368/ab48a2be-011c-11e6-9405-fe023542ff59.png)
