### PR TITLE
Add a location button in the Survey example

### DIFF
--- a/src/Commands/UserCommands/SurveyCommand.php
+++ b/src/Commands/UserCommands/SurveyCommand.php
@@ -151,8 +151,22 @@ class SurveyCommand extends UserCommand
                     $this->conversation->notes['state'] = 4;
                     $this->conversation->update();
 
+                    $keyboard = [];
+                    $keyboard[] = [
+                        [ 'text' => 'request_contact', 'request_contact' => true ],
+                        [ 'text' => 'request_location', 'request_location' => true ]
+                            ];
+                    $reply_keyboard_markup = new ReplyKeyboardMarkup(
+                        [
+                            'keyboard' => $keyboard ,
+                            'resize_keyboard' => true,
+                            'one_time_keyboard' => true,
+                            'selective' => true
+                            ]
+                    );
+                    $data['reply_markup'] = $reply_keyboard_markup;
+
                     $data['text'] = 'Insert your home location (need location object):';
-                    $data['reply_markup'] = new ReplyKeyBoardHide(['selective' => true]);
                     $result = Request::sendMessage($data);
                     break;
                 }
@@ -174,6 +188,7 @@ class SurveyCommand extends UserCommand
 
                 // no break
             case 6:
+                $this->conversation->update();
                 $out_text = '/Survey result:' . "\n";
                 unset($this->conversation->notes['state']);
                 foreach ($this->conversation->notes as $k => $v) {


### PR DESCRIPTION
Add a location button in a custom keyboard so the user can finish the survey example. 
Store the user's picture id in the conversation notes.