### PR TITLE
Add Location button in a custom keyboard so the user can finish the survey example

### DIFF
--- a/src/Commands/UserCommands/SurveyCommand.php
+++ b/src/Commands/UserCommands/SurveyCommand.php
@@ -150,10 +150,16 @@ class SurveyCommand extends UserCommand
                 if (is_null($message->getLocation())) {
                     $this->conversation->notes['state'] = 4;
                     $this->conversation->update();
-
-                    $data['text'] = 'Insert your home location (need location object):';
-                    $data['reply_markup'] = new ReplyKeyBoardHide(['selective' => true]);
-                    $result = Request::sendMessage($data);
+                    $data['reply_markup'] = new ReplyKeyboardMarkup([
+                        'keyboard' => [[
+                            [ 'text' => 'Share Location', 'request_location' => true ],
+                        ]],
+                        'resize_keyboard'   => true,
+                        'one_time_keyboard' => true,
+                        'selective'         => true,
+                    ]);
+		    $data['text'] = 'Share your current location:';
+		    $result = Request::sendMessage($data);
                     break;
                 }
 
@@ -172,8 +178,29 @@ class SurveyCommand extends UserCommand
                 }
                 $this->conversation->notes['photo_id'] = $message->getPhoto()[0]->getFileId();
 
-                // no break
+		// no break
             case 6:
+                if (is_null($message->getContact())) {
+                    $this->conversation->notes['state'] = 6;
+                    $this->conversation->update();
+
+		    $data['text'] = 'Share your contact information:';
+                    $data['reply_markup'] = new ReplyKeyboardMarkup([
+                        'keyboard' => [[
+                            [ 'text' => 'Share Contact', 'request_contact' => true ],
+                        ]],
+                        'resize_keyboard'   => true,
+                        'one_time_keyboard' => true,
+                        'selective'         => true,
+                    ]);
+                    $result = Request::sendMessage($data);
+                    break;
+                }
+                $this->conversation->notes['phone_number'] = $message->getContact()->getPhoneNumber();
+
+		// no break
+            case 7:
+                $this->conversation->update();
                 $out_text = '/Survey result:' . "\n";
                 unset($this->conversation->notes['state']);
                 foreach ($this->conversation->notes as $k => $v) {

--- a/src/Commands/UserCommands/SurveyCommand.php
+++ b/src/Commands/UserCommands/SurveyCommand.php
@@ -158,8 +158,8 @@ class SurveyCommand extends UserCommand
                         'one_time_keyboard' => true,
                         'selective'         => true,
                     ]);
-		    $data['text'] = 'Share your current location:';
-		    $result = Request::sendMessage($data);
+                    $data['text'] = 'Share your location:';
+                    $result = Request::sendMessage($data);
                     break;
                 }
 
@@ -178,13 +178,13 @@ class SurveyCommand extends UserCommand
                 }
                 $this->conversation->notes['photo_id'] = $message->getPhoto()[0]->getFileId();
 
-		// no break
+        // no break
             case 6:
                 if (is_null($message->getContact())) {
                     $this->conversation->notes['state'] = 6;
                     $this->conversation->update();
 
-		    $data['text'] = 'Share your contact information:';
+                    $data['text'] = 'Share your contact information:';
                     $data['reply_markup'] = new ReplyKeyboardMarkup([
                         'keyboard' => [[
                             [ 'text' => 'Share Contact', 'request_contact' => true ],
@@ -198,7 +198,7 @@ class SurveyCommand extends UserCommand
                 }
                 $this->conversation->notes['phone_number'] = $message->getContact()->getPhoneNumber();
 
-		// no break
+        // no break
             case 7:
                 $this->conversation->update();
                 $out_text = '/Survey result:' . "\n";


### PR DESCRIPTION
Add Location button in a custom keyboard so the user can finish the survey example.
Create an additional state where the bot asks the phone number with 'request_contact' button.
Store the user's picture id and user's phone number in the conversation notes.