### PR TITLE
Add inline line breaks in logs.

### DIFF
--- a/src/TelegramLog.php
+++ b/src/TelegramLog.php
@@ -100,7 +100,11 @@ class TelegramLog
         }
         self::initialize();
         self::$error_log_path = $path;
-        return self::$monolog->pushHandler(new StreamHandler(self::$error_log_path, Logger::ERROR));
+
+        return self::$monolog->pushHandler(
+            (new StreamHandler(self::$error_log_path, Logger::ERROR))
+                ->setFormatter(new LineFormatter(null, null, true))
+        );
     }
 
     /**
@@ -117,7 +121,11 @@ class TelegramLog
         }
         self::initialize();
         self::$debug_log_path = $path;
-        return self::$monolog->pushHandler(new StreamHandler(self::$debug_log_path, Logger::DEBUG));
+
+        return self::$monolog->pushHandler(
+            (new StreamHandler(self::$debug_log_path, Logger::DEBUG))
+                ->setFormatter(new LineFormatter(null, null, true))
+        );
     }
 
     /**


### PR DESCRIPTION
By default, Monolog removes all line breaks, resulting in a log file that has really long lines.
For debug purposes, it's very difficult to find the relevant info in a long line.

This PR enables line breaks in debug and error logs.