### PR TITLE
Using getUpdates needs a valid database connection.

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -291,6 +291,13 @@ class Telegram
      */
     public function handleGetUpdates($limit = null, $timeout = null)
     {
+        if (!DB::isDbConnected()) {
+            return new Entities\ServerResponse([
+                'ok'          => false,
+                'description' => 'getUpdates needs MySQL connection!',
+            ], $this->bot_name);
+        }
+
         //DB Query
         $last_update = DB::selectTelegramUpdate(1);
 


### PR DESCRIPTION
Make sure that a valid database connection exists when using `getUpdates()`.
This doesn't solve the loop problem, but it prevents loop messages from being sent.

Fixes #127 