### PR TITLE
Fix cancel command if no database is connected.

### DIFF
--- a/src/Commands/UserCommands/CancelCommand.php
+++ b/src/Commands/UserCommands/CancelCommand.php
@@ -60,7 +60,7 @@ class CancelCommand extends UserCommand
      */
     public function executeNoDb()
     {
-        return $this->hideKeyboard();
+        return $this->hideKeyboard('Nothing to cancel.');
     }
 
     /**
@@ -70,7 +70,7 @@ class CancelCommand extends UserCommand
      *
      * @return Entities\ServerResponse
      */
-    private function hideKeyboard($text = '')
+    private function hideKeyboard($text)
     {
         return Request::sendMessage([
             'reply_markup' => new ReplyKeyboardHide(['selective' => true]),


### PR DESCRIPTION
Message mustn't have an empty text, otherwise Telegram API is sad 😢 

So just output a simple message instead, since there is nothing to cancel if there is no database connection, as no conversation can be active anyway.