### PR TITLE
Improve test code

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.6/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
         bootstrap="./tests/Bootstrap.php"
         backupGlobals="false"
         backupStaticAttributes="false"
@@ -23,6 +23,10 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <const name="PHPUNIT_TESTSUITE" value="true"/>
+        <const name="PHPUNIT_DB_HOST" value="127.0.0.1"/>
+        <const name="PHPUNIT_DB_NAME" value="telegrambot"/>
+        <const name="PHPUNIT_DB_USER" value="root"/>
+        <const name="PHPUNIT_DB_PASS" value=""/>
     </php>
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/structure.sql
+++ b/structure.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS `chat` (
   KEY `old_id` (`old_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE IF NOT EXISTS  `user_chat` (
+CREATE TABLE IF NOT EXISTS `user_chat` (
   `user_id` bigint COMMENT 'Unique user identifier',
   `chat_id` bigint COMMENT 'Unique user or chat identifier',
 

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -23,12 +23,29 @@ use Longman\TelegramBot\Telegram;
  */
 class CommandTest extends TestCase
 {
+    /**
+     * @var string
+     */
     private $command_namespace = 'Longman\TelegramBot\Commands\Command';
 
+    /**
+     * @var \Longman\TelegramBot\Telegram
+     */
     private $telegram;
+
+    /**
+     * @var \Longman\TelegramBot\Commands\Command
+     */
     private $command_stub;
 
+    /**
+     * @var \Longman\TelegramBot\Telegram
+     */
     private $telegram_with_config;
+
+    /**
+     * @var \Longman\TelegramBot\Commands\Command
+     */
     private $command_stub_with_config;
 
     public function setUp()

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -51,11 +51,11 @@ class CommandTest extends TestCase
     public function setUp()
     {
         //Default command object
-        $this->telegram = new Telegram('apikey', 'botname');
+        $this->telegram = new Telegram('apikey', 'testbot');
         $this->command_stub = $this->getMockForAbstractClass($this->command_namespace, [$this->telegram]);
 
         //Create separate command object that contain a command config
-        $this->telegram_with_config = new Telegram('apikey', 'botname');
+        $this->telegram_with_config = new Telegram('apikey', 'testbot');
         $this->telegram_with_config->setCommandConfig('command_name', ['config_key' => 'config_value']);
         $this->command_stub_with_config = $this->getMockBuilder($this->command_namespace)
              ->disableOriginalConstructor()

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -48,9 +48,6 @@ class CommandTest extends TestCase
         $this->command_stub_with_config->__construct($this->telegram_with_config);
     }
 
-    /**
-     * @test
-     */
     public function testCommandConstructorNeedsTelegramObject()
     {
         $error_message = 'must be an instance of Longman\TelegramBot\Telegram';
@@ -72,87 +69,57 @@ class CommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
     public function testCommandHasCorrectTelegramObject()
     {
         $this->assertAttributeEquals($this->telegram, 'telegram', $this->command_stub);
         $this->assertSame($this->telegram, $this->command_stub->getTelegram());
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandName()
     {
         $this->assertAttributeEquals('', 'name', $this->command_stub);
         $this->assertEmpty($this->command_stub->getName());
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandDescription()
     {
         $this->assertAttributeEquals('Command description', 'description', $this->command_stub);
         $this->assertEquals('Command description', $this->command_stub->getDescription());
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandUsage()
     {
         $this->assertAttributeEquals('Command usage', 'usage', $this->command_stub);
         $this->assertEquals('Command usage', $this->command_stub->getUsage());
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandVersion()
     {
         $this->assertAttributeEquals('1.0.0', 'version', $this->command_stub);
         $this->assertEquals('1.0.0', $this->command_stub->getVersion());
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandIsEnabled()
     {
         $this->assertAttributeEquals(true, 'enabled', $this->command_stub);
         $this->assertTrue($this->command_stub->isEnabled());
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandNeedsMysql()
     {
         $this->assertAttributeEquals(false, 'need_mysql', $this->command_stub);
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandEmptyConfig()
     {
         $this->assertAttributeEquals([], 'config', $this->command_stub);
     }
 
-    /**
-     * @test
-     */
     public function testDefaultCommandUpdateNull()
     {
         $this->assertAttributeEquals(null, 'update', $this->command_stub);
     }
 
-    /**
-     * @test
-     */
     public function testCommandSetUpdateAndMessage()
     {
         $stub = $this->command_stub;
@@ -174,17 +141,11 @@ class CommandTest extends TestCase
         $this->assertEquals($message, $stub->getMessage());
     }
 
-    /**
-     * @test
-     */
     public function testCommandWithConfigNotEmptyConfig()
     {
         $this->assertAttributeNotEmpty('config', $this->command_stub_with_config);
     }
 
-    /**
-     * @test
-     */
     public function testCommandWithConfigCorrectConfig()
     {
         $this->assertAttributeEquals(['config_key' => 'config_value'], 'config', $this->command_stub_with_config);

--- a/tests/Unit/Commands/CommandTestCase.php
+++ b/tests/Unit/Commands/CommandTestCase.php
@@ -37,7 +37,7 @@ class CommandTestCase extends TestCase
      */
     public function setUp()
     {
-        $this->telegram = new Telegram('apikey', 'botname');
+        $this->telegram = new Telegram('apikey', 'testbot');
         $this->telegram->addCommandsPath(BASE_COMMANDS_PATH . '/UserCommands');
         $this->telegram->getCommandsList();
     }

--- a/tests/Unit/Commands/CommandTestCase.php
+++ b/tests/Unit/Commands/CommandTestCase.php
@@ -22,9 +22,19 @@ use Longman\TelegramBot\Telegram;
  */
 class CommandTestCase extends TestCase
 {
+    /**
+     * @var \Longman\TelegramBot\Telegram
+     */
     protected $telegram;
+
+    /**
+     * @var \Longman\TelegramBot\Commands\Command
+     */
     protected $command;
 
+    /**
+     * setUp
+     */
     public function setUp()
     {
         $this->telegram = new Telegram('apikey', 'botname');

--- a/tests/Unit/Commands/CommandTestCase.php
+++ b/tests/Unit/Commands/CommandTestCase.php
@@ -34,8 +34,6 @@ class CommandTestCase extends TestCase
 
     /**
      * Make sure the version number is in the format x.x.x, x.x or x
-     *
-     * @test
      */
     public function testVersionNumberFormat()
     {

--- a/tests/Unit/Commands/UserCommands/EchoCommandTest.php
+++ b/tests/Unit/Commands/UserCommands/EchoCommandTest.php
@@ -30,9 +30,6 @@ class EchoCommandTest extends CommandTestCase
         $this->command = new EchoCommand($this->telegram);
     }
 
-    /**
-     * @test
-     */
     public function testEchoCommandProperties()
     {
         $this->assertAttributeEquals('echo', 'name', $this->command);
@@ -40,9 +37,6 @@ class EchoCommandTest extends CommandTestCase
         $this->assertAttributeEquals('/echo <text>', 'usage', $this->command);
     }
 
-    /**
-     * @test
-     */
     public function testEchoCommandExecuteWithoutParameter()
     {
         $text = $this->command
@@ -60,9 +54,6 @@ class EchoCommandTest extends CommandTestCase
         $this->assertEquals('Command usage: /echo <text>', $text);
     }
 
-    /**
-     * @test
-     */
     public function testEchoCommandExecuteWithParameter()
     {
         $text = $this->command

--- a/tests/Unit/Commands/UserCommands/EchoCommandTest.php
+++ b/tests/Unit/Commands/UserCommands/EchoCommandTest.php
@@ -24,6 +24,9 @@ use Longman\TelegramBot\Commands\UserCommands\EchoCommand;
  */
 class EchoCommandTest extends CommandTestCase
 {
+    /**
+     * setUp
+     */
     public function setUp()
     {
         parent::setUp();

--- a/tests/Unit/Commands/UserCommands/HelpCommandTest.php
+++ b/tests/Unit/Commands/UserCommands/HelpCommandTest.php
@@ -47,7 +47,7 @@ class HelpCommandTest extends CommandTestCase
             ->getResult()
             ->getText();
         $this->assertContains(
-            "botname v. " . $this->telegram->getVersion() . "\n\nCommands List:",
+            'testbot v. ' . $this->telegram->getVersion() . "\n\nCommands List:",
             $text
         );
     }

--- a/tests/Unit/Commands/UserCommands/HelpCommandTest.php
+++ b/tests/Unit/Commands/UserCommands/HelpCommandTest.php
@@ -23,6 +23,9 @@ use Longman\TelegramBot\Commands\UserCommands\HelpCommand;
  */
 class HelpCommandTest extends CommandTestCase
 {
+    /**
+     * setUp
+     */
     public function setUp()
     {
         parent::setUp();

--- a/tests/Unit/Commands/UserCommands/HelpCommandTest.php
+++ b/tests/Unit/Commands/UserCommands/HelpCommandTest.php
@@ -29,9 +29,6 @@ class HelpCommandTest extends CommandTestCase
         $this->command = new HelpCommand($this->telegram);
     }
 
-    /**
-     * @test
-     */
     public function testHelpCommandProperties()
     {
         $this->assertAttributeEquals('help', 'name', $this->command);
@@ -39,9 +36,6 @@ class HelpCommandTest extends CommandTestCase
         $this->assertAttributeEquals('/help or /help <command>', 'usage', $this->command);
     }
 
-    /**
-     * @test
-     */
     public function testHelpCommandExecuteWithoutParameter()
     {
         $text = $this->command
@@ -55,9 +49,6 @@ class HelpCommandTest extends CommandTestCase
         );
     }
 
-    /**
-     * @test
-     */
     public function testHelpCommandExecuteWithParameterInvalidCommand()
     {
         $text = $this->command
@@ -68,9 +59,6 @@ class HelpCommandTest extends CommandTestCase
         $this->assertEquals('No help available: Command /invalidcommand not found', $text);
     }
 
-    /**
-     * @test
-     */
     public function testHelpCommandExecuteWithParameterValidCommand()
     {
         $text = $this->command

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -57,7 +57,7 @@ class ConversationTest extends TestCase
 
     public function testConversationThatExistsPropertiesSetCorrectly()
     {
-        $info = TestHelpers::startFakeConversation('command');
+        $info = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
         $this->assertAttributeEquals($info['user_id'], 'user_id', $conversation);
         $this->assertAttributeEquals($info['chat_id'], 'chat_id', $conversation);
@@ -81,7 +81,7 @@ class ConversationTest extends TestCase
 
     public function testNewConversationThatWontExistWithoutCommand()
     {
-        TestHelpers::startFakeConversation(null);
+        TestHelpers::startFakeConversation();
         $conversation = new Conversation(0, 0);
         $this->assertFalse($conversation->exists());
         $this->assertNull($conversation->getCommand());
@@ -89,7 +89,7 @@ class ConversationTest extends TestCase
 
     public function testNewConversationThatWillExistWithCommand()
     {
-        $info = TestHelpers::startFakeConversation('command');
+        $info = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
         $this->assertTrue($conversation->exists());
         $this->assertEquals('command', $conversation->getCommand());
@@ -97,7 +97,7 @@ class ConversationTest extends TestCase
 
     public function testStopConversation()
     {
-        $info = TestHelpers::startFakeConversation('command');
+        $info = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
         $this->assertTrue($conversation->exists());
         $conversation->stop();
@@ -108,7 +108,7 @@ class ConversationTest extends TestCase
 
     public function testCancelConversation()
     {
-        $info = TestHelpers::startFakeConversation('command');
+        $info = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
         $this->assertTrue($conversation->exists());
         $conversation->cancel();
@@ -119,7 +119,7 @@ class ConversationTest extends TestCase
 
     public function testUpdateConversationNotes()
     {
-        $info = TestHelpers::startFakeConversation('command');
+        $info = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
         $conversation->notes = 'newnote';
         $conversation->update();

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -40,7 +40,7 @@ class ConversationTest extends TestCase
             'password' => PHPUNIT_DB_PASS,
         ];
 
-        $this->telegram = new Telegram('testapikey', 'testbotname');
+        $this->telegram = new Telegram('apikey', 'testbot');
         $this->telegram->enableMySql($credentials);
 
         //Make sure we start with an empty DB for each test.

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -47,10 +47,7 @@ class ConversationTest extends TestCase
         TestHelpers::emptyDB($credentials);
     }
 
-    /**
-     * @test
-     */
-    public function conversationThatDoesntExistPropertiesSetCorrectly()
+    public function testConversationThatDoesntExistPropertiesSetCorrectly()
     {
         $conversation = new Conversation(123, 456);
         $this->assertAttributeEquals(123, 'user_id', $conversation);
@@ -58,10 +55,7 @@ class ConversationTest extends TestCase
         $this->assertAttributeEquals(null, 'command', $conversation);
     }
 
-    /**
-     * @test
-     */
-    public function conversationThatExistsPropertiesSetCorrectly()
+    public function testConversationThatExistsPropertiesSetCorrectly()
     {
         $info = TestHelpers::startFakeConversation('command');
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
@@ -70,10 +64,7 @@ class ConversationTest extends TestCase
         $this->assertAttributeEquals('command', 'command', $conversation);
     }
 
-    /**
-     * @test
-     */
-    public function conversationThatDoesntExistWithoutCommand()
+    public function testConversationThatDoesntExistWithoutCommand()
     {
         $conversation = new Conversation(1, 1);
         $this->assertFalse($conversation->exists());
@@ -81,18 +72,14 @@ class ConversationTest extends TestCase
     }
 
     /**
-     * @test
      * @expectedException \Longman\TelegramBot\Exception\TelegramException
      */
-    public function conversationThatDoesntExistWithCommand()
+    public function testConversationThatDoesntExistWithCommand()
     {
         new Conversation(1, 1, 'command');
     }
 
-    /**
-     * @test
-     */
-    public function newConversationThatWontExistWithoutCommand()
+    public function testNewConversationThatWontExistWithoutCommand()
     {
         TestHelpers::startFakeConversation(null);
         $conversation = new Conversation(0, 0);
@@ -100,10 +87,7 @@ class ConversationTest extends TestCase
         $this->assertNull($conversation->getCommand());
     }
 
-    /**
-     * @test
-     */
-    public function newConversationThatWillExistWithCommand()
+    public function testNewConversationThatWillExistWithCommand()
     {
         $info = TestHelpers::startFakeConversation('command');
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
@@ -111,10 +95,7 @@ class ConversationTest extends TestCase
         $this->assertEquals('command', $conversation->getCommand());
     }
 
-    /**
-     * @test
-     */
-    public function stopConversation()
+    public function testStopConversation()
     {
         $info = TestHelpers::startFakeConversation('command');
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
@@ -125,10 +106,7 @@ class ConversationTest extends TestCase
         $this->assertFalse($conversation2->exists());
     }
 
-    /**
-     * @test
-     */
-    public function cancelConversation()
+    public function testCancelConversation()
     {
         $info = TestHelpers::startFakeConversation('command');
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
@@ -139,10 +117,7 @@ class ConversationTest extends TestCase
         $this->assertFalse($conversation2->exists());
     }
 
-    /**
-     * @test
-     */
-    public function updateConversationNotes()
+    public function testUpdateConversationNotes()
     {
         $info = TestHelpers::startFakeConversation('command');
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -34,14 +34,14 @@ class ConversationTest extends TestCase
     protected function setUp()
     {
         $credentials = [
-            'host'     => '127.0.0.1',
-            'user'     => 'root',
-            'password' => '',
-            'database' => 'telegrambot',
+            'host'     => PHPUNIT_DB_HOST,
+            'database' => PHPUNIT_DB_NAME,
+            'user'     => PHPUNIT_DB_USER,
+            'password' => PHPUNIT_DB_PASS,
         ];
 
         $this->telegram = new Telegram('testapikey', 'testbotname');
-        $this->telegram->enableMySQL($credentials);
+        $this->telegram->enableMySql($credentials);
 
         //Make sure we start with an empty DB for each test.
         TestHelpers::emptyDB($credentials);

--- a/tests/Unit/Entities/ChatTest.php
+++ b/tests/Unit/Entities/ChatTest.php
@@ -33,11 +33,7 @@ class ChatTest extends TestCase
     {
     }
 
-    /**
-     * @test
-     */
- 
-    public function testChatType() 
+    public function testChatType()
     {
 
         $this->chat = new Chat(json_decode('{"id":123,"title":null,"first_name":"john","last_name":null,"username":"null"}',true));

--- a/tests/Unit/Entities/ChatTest.php
+++ b/tests/Unit/Entities/ChatTest.php
@@ -10,7 +10,8 @@
 
 namespace Tests\Unit;
 
-use \Longman\TelegramBot\Entities\Chat;
+use Longman\TelegramBot\Entities\Chat;
+use Tests\TestHelpers;
 
 /**
  * @package         TelegramTest
@@ -35,14 +36,13 @@ class ChatTest extends TestCase
 
     public function testChatType()
     {
-
-        $this->chat = new Chat(json_decode('{"id":123,"title":null,"first_name":"john","last_name":null,"username":"null"}',true));
+        $this->chat = TestHelpers::getFakeChatObject();
         $this->assertEquals('private', $this->chat->getType());
 
-        $this->chat = new Chat(json_decode('{"id":-123,"title":"ChatTitle","first_name":null,"last_name":null,"username":"null"}',true));
+        $this->chat = TestHelpers::getFakeChatObject(['id' => -123, 'type' => null]);
         $this->assertEquals('group', $this->chat->getType());
 
-        $this->chat = new Chat(json_decode('{"id":-123,"type":"channel","title":"ChatTitle","first_name":null,"last_name":null,"username":"null"}',true));
+        $this->chat = TestHelpers::getFakeChatObject(['id' => -123, 'type' => 'channel']);
         $this->assertEquals('channel', $this->chat->getType());
     }
 }

--- a/tests/Unit/Entities/ChatTest.php
+++ b/tests/Unit/Entities/ChatTest.php
@@ -13,16 +13,16 @@ namespace Tests\Unit;
 use \Longman\TelegramBot\Entities\Chat;
 
 /**
- * @package 		TelegramTest
- * @author 		Avtandil Kikabidze <akalongman@gmail.com>
- * @copyright 		Avtandil Kikabidze <akalongman@gmail.com>
- * @license 		http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link 			http://www.github.com/akalongman/php-telegram-bot
+ * @package         TelegramTest
+ * @author          Avtandil Kikabidze <akalongman@gmail.com>
+ * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
+ * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
+ * @link            http://www.github.com/akalongman/php-telegram-bot
  */
 class ChatTest extends TestCase
 {
     /**
-    * @var \Longman\TelegramBot\Telegram
+    * @var \Longman\TelegramBot\Entities\Chat
     */
     private $chat;
     

--- a/tests/Unit/Entities/ChatTest.php
+++ b/tests/Unit/Entities/ChatTest.php
@@ -26,13 +26,6 @@ class ChatTest extends TestCase
     * @var \Longman\TelegramBot\Entities\Chat
     */
     private $chat;
-    
-    /**
-    * setUp
-    */
-    protected function setUp()
-    {
-    }
 
     public function testChatType()
     {

--- a/tests/Unit/Entities/MessageTest.php
+++ b/tests/Unit/Entities/MessageTest.php
@@ -13,16 +13,16 @@ namespace Tests\Unit;
 use \Longman\TelegramBot\Entities\Message;
 
 /**
- * @package 		TelegramTest
- * @author 		Avtandil Kikabidze <akalongman@gmail.com>
- * @copyright 		Avtandil Kikabidze <akalongman@gmail.com>
- * @license 		http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link 			http://www.github.com/akalongman/php-telegram-bot
+ * @package         TelegramTest
+ * @author          Avtandil Kikabidze <akalongman@gmail.com>
+ * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
+ * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
+ * @link            http://www.github.com/akalongman/php-telegram-bot
  */
 class MessageTest extends TestCase
 {
     /**
-     * @var \Longman\TelegramBot\Telegram
+     * @var \Longman\TelegramBot\Entities\Message
      */
     private $message;
 

--- a/tests/Unit/Entities/MessageTest.php
+++ b/tests/Unit/Entities/MessageTest.php
@@ -10,7 +10,7 @@
 
 namespace Tests\Unit;
 
-use \Longman\TelegramBot\Entities\Message;
+use Tests\TestHelpers;
 
 /**
  * @package         TelegramTest
@@ -33,75 +33,58 @@ class MessageTest extends TestCase
     {
     }
 
-    protected function generateMessage($string) {
-
-        $string = str_replace("\n", "\\n", $string);
-        $json = '{"message_id":961,"from":{"id":123,"first_name":"john","username":"john"},"chat":{"id":123,"title":null,"first_name":"john","last_name":null,"username":"null"},"date":1435920612,"text":"'.$string.'"}';
-        //$json = utf8_encode($json);
-        return json_decode($json, true);
-    }
-
     public function testTextAndCommandRecognise() {
         // /command
-        $this->message = new Message($this->generateMessage('/help'), 'testbot');
-
+        $this->message = TestHelpers::getFakeMessageObject(['text' => '/help']);
         $this->assertEquals('/help', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals('/help', $this->message->getText());
         $this->assertEquals('', $this->message->getText(true));
 
         // text
-        $this->message = new Message($this->generateMessage('some text'), 'testbot');
-
+        $this->message = TestHelpers::getFakeMessageObject(['text' => 'some text']);
         $this->assertEquals('', $this->message->getFullCommand());
         $this->assertEquals('', $this->message->getCommand());
         $this->assertEquals('some text', $this->message->getText());
         $this->assertEquals('some text', $this->message->getText(true));
 
-
         // /command@bot
-
-        $this->message = new Message($this->generateMessage('/help@testbot'), 'testbot');
+        $this->message = TestHelpers::getFakeMessageObject(['text' => '/help@testbot']);
         $this->assertEquals('/help@testbot', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals('/help@testbot', $this->message->getText());
         $this->assertEquals('', $this->message->getText(true));
 
         // /commmad text
-        $this->message = new Message($this->generateMessage('/help some text'), 'testbot');
+        $this->message = TestHelpers::getFakeMessageObject(['text' => '/help some text']);
         $this->assertEquals('/help', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals('/help some text', $this->message->getText());
         $this->assertEquals('some text', $this->message->getText(true));
 
         // /command@bot some text
-        $this->message = new Message($this->generateMessage('/help@testbot some text'), 'testbot');
+        $this->message = TestHelpers::getFakeMessageObject(['text' => '/help@testbot some text']);
         $this->assertEquals('/help@testbot', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals('/help@testbot some text', $this->message->getText());
         $this->assertEquals('some text', $this->message->getText(true));
 
         // /commmad\n text
-
-//$array = $this->generateMessage("/help\n some text");
-////print_r($this->generateMessage('/help@testbot'));
-//echo 'value:';
-//print_r($array);
-        $this->message = new Message($this->generateMessage("/help\n some text"), 'testbot');
+        $this->message = TestHelpers::getFakeMessageObject(['text' => "/help\n some text"]);
         $this->assertEquals('/help', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals("/help\n some text", $this->message->getText());
         $this->assertEquals(' some text', $this->message->getText(true));
 
         // /command@bot\nsome text
-        $this->message = new Message($this->generateMessage("/help@testbot\nsome text"), 'testbot');
+        $this->message = TestHelpers::getFakeMessageObject(['text' => "/help@testbot\nsome text"]);
         $this->assertEquals('/help@testbot', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals("/help@testbot\nsome text", $this->message->getText());
         $this->assertEquals('some text', $this->message->getText(true));
 
         // /command@bot \nsome text
-        $this->message = new Message($this->generateMessage("/help@testbot \nsome text"), 'testbot');
+        $this->message = TestHelpers::getFakeMessageObject(['text' => "/help@testbot \nsome text"]);
         $this->assertEquals('/help@testbot', $this->message->getFullCommand());
         $this->assertEquals('help', $this->message->getCommand());
         $this->assertEquals("/help@testbot \nsome text", $this->message->getText());

--- a/tests/Unit/Entities/MessageTest.php
+++ b/tests/Unit/Entities/MessageTest.php
@@ -26,13 +26,6 @@ class MessageTest extends TestCase
      */
     private $message;
 
-    /**
-     * setUp
-     */
-    protected function setUp()
-    {
-    }
-
     public function testTextAndCommandRecognise() {
         // /command
         $this->message = TestHelpers::getFakeMessageObject(['text' => '/help']);

--- a/tests/Unit/Entities/MessageTest.php
+++ b/tests/Unit/Entities/MessageTest.php
@@ -40,9 +40,6 @@ class MessageTest extends TestCase
         //$json = utf8_encode($json);
         return json_decode($json, true);
     }
-    /**
-     * @test
-     */
 
     public function testTextAndCommandRecognise() {
         // /command

--- a/tests/Unit/Entities/ReplyToMessageTest.php
+++ b/tests/Unit/Entities/ReplyToMessageTest.php
@@ -39,7 +39,7 @@ class ReplyToMessageTest extends TestCase
 "message":{"message_id":4479,"from":{"id":123,"first_name":"John","username":"MJohn"},"chat":{"id":-123,"title":"MyChat","type":"group"},"date":1449092987,"reply_to_message":{"message_id":11,"from":{"id":121,"first_name":"Myname","username":"mybot"},"chat":{"id":-123,"title":"MyChat","type":"group"},"date":1449092984,"text":"type some text"},"text":"some text"}}
 ';
         $struct = json_decode($json, true);
-        $update = new Update($struct,'mybot');
+        $update = new Update($struct, 'mybot');
 
         $this->message = $update->getMessage();
         $this->reply_to_message = $this->message->getReplyToMessage();

--- a/tests/Unit/Entities/ReplyToMessageTest.php
+++ b/tests/Unit/Entities/ReplyToMessageTest.php
@@ -14,25 +14,25 @@ use \Longman\TelegramBot\Entities\Update;
 use \Longman\TelegramBot\Entities\ReplyToMessage;
 
 /**
- * @package 		TelegramTest
- * @author 		Avtandil Kikabidze <akalongman@gmail.com>
- * @copyright 		Avtandil Kikabidze <akalongman@gmail.com>
- * @license 		http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link 			http://www.github.com/akalongman/php-telegram-bot
+ * @package         TelegramTest
+ * @author          Avtandil Kikabidze <akalongman@gmail.com>
+ * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
+ * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
+ * @link            http://www.github.com/akalongman/php-telegram-bot
  */
 class ReplyToMessageTest extends TestCase
 {
     /**
-    * @var \Longman\TelegramBot\Telegram
-    */
+     * @var \Longman\TelegramBot\Entities\Message
+     */
     private $reply_to_message;
-    private $message;
 
     /**
-     * @test
+     * @var \Longman\TelegramBot\Entities\Message
      */
- 
-    public function testChatType() 
+    private $message;
+
+    public function testChatType()
     {
         $json = '
 {"update_id":137809335,

--- a/tests/Unit/Entities/ServerResponseTest.php
+++ b/tests/Unit/Entities/ServerResponseTest.php
@@ -37,10 +37,6 @@ class ServerResponseTest extends TestCase
     {
     }
 
-    /**
-     * @test
-     */
-
     public function sendMessageOk()
     {
         return '{
@@ -80,10 +76,6 @@ class ServerResponseTest extends TestCase
 
     }
 
-    /**
-     * @test
-     */
-
     public function sendMessageFail()
     {
         return '{
@@ -105,10 +97,6 @@ class ServerResponseTest extends TestCase
         $this->assertEquals('Error: Bad Request: wrong chat id', $this->server->getDescription());
     }
 
-    /**
-     * @test
-     */
-
    public function setWebHookOk()
     {
         return '{"ok":true,"result":true,"description":"Webhook was set"}';
@@ -125,10 +113,6 @@ class ServerResponseTest extends TestCase
         $this->assertNull($this->server->getErrorCode());
         $this->assertEquals('Webhook was set', $this->server->getDescription());
     }
-
-    /**
-     * @test
-     */
 
     public function setWebHookFail()
     {
@@ -151,12 +135,6 @@ class ServerResponseTest extends TestCase
         $this->assertEquals(400, $this->server->getErrorCode());
         $this->assertEquals("Error: Bad request: htttps://domain.host.org/dir/hook.php", $this->server->getDescription());
     }
-
-
-
-    /**
-     * @test
-     */
 
     public function getUpdatesArray()
     {
@@ -210,10 +188,6 @@ class ServerResponseTest extends TestCase
         $this->assertInstanceOf('\Longman\TelegramBot\Entities\Update', $this->server->getResult()[0]);
     }
 
-    /**
-     * @test
-     */
-
     public function getUpdatesEmpty()
     {
         return '{"ok":true,"result":[]}';
@@ -225,12 +199,6 @@ class ServerResponseTest extends TestCase
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
         $this->assertNull($this->server->getResult());
     }
-
-
-    /**
-     * @test
-     */
-
 
     public function getUserProfilePhotos()
     {
@@ -273,12 +241,6 @@ class ServerResponseTest extends TestCase
 
     }
 
-
-    /**
-     * @test
-     */
-
-
     public function getFile()
     {
         return '{
@@ -302,11 +264,6 @@ class ServerResponseTest extends TestCase
         $this->assertInstanceOf('\Longman\TelegramBot\Entities\File', $this->server->getResult());
 
     }
-
-
-    /**
-     * @test
-     */
 
     public function testSetGeneralTestFakeResponse() {
         //setWebhook ok

--- a/tests/Unit/Entities/ServerResponseTest.php
+++ b/tests/Unit/Entities/ServerResponseTest.php
@@ -30,13 +30,6 @@ class ServerResponseTest extends TestCase
     */
     private $server;
 
-    /**
-    * setUp
-    */
-    protected function setUp()
-    {
-    }
-
     public function sendMessageOk()
     {
         return '{
@@ -47,31 +40,30 @@ class ServerResponseTest extends TestCase
                 "chat":{"id":123456789,"first_name":"john","username":"Mjohn"},
                 "date":1441378360,
                 "text":"hello"
-                }
-            }';
+            }
+        }';
     }
 
     public function testSendMessageOk() {
-
         $result = $this->sendMessageOk();
-
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
+        $server_result = $this->server->getResult();
 
         $this->assertTrue($this->server->isOk());
-        $this->assertInstanceOf('\Longman\TelegramBot\Entities\Message', $this->server->getResult());
         $this->assertNull($this->server->getErrorCode());
         $this->assertNull($this->server->getDescription());
+        $this->assertInstanceOf('\Longman\TelegramBot\Entities\Message', $server_result);
 
         //Message
-        $this->assertEquals('1234', $this->server->getResult()->getMessageId());
-        $this->assertEquals('123456789', $this->server->getResult()->getFrom()->getId());
-        $this->assertEquals('botname', $this->server->getResult()->getFrom()->getFirstName());
-        $this->assertEquals('namebot', $this->server->getResult()->getFrom()->getUserName());
-        $this->assertEquals('123456789', $this->server->getResult()->getChat()->getId());
-        $this->assertEquals('john', $this->server->getResult()->getChat()->getFirstName());
-        $this->assertEquals('Mjohn', $this->server->getResult()->getChat()->getUserName());
-        $this->assertEquals('1441378360', $this->server->getResult()->getDate());
-        $this->assertEquals('hello', $this->server->getResult()->getText());
+        $this->assertEquals('1234', $server_result->getMessageId());
+        $this->assertEquals('123456789', $server_result->getFrom()->getId());
+        $this->assertEquals('botname', $server_result->getFrom()->getFirstName());
+        $this->assertEquals('namebot', $server_result->getFrom()->getUserName());
+        $this->assertEquals('123456789', $server_result->getChat()->getId());
+        $this->assertEquals('john', $server_result->getChat()->getFirstName());
+        $this->assertEquals('Mjohn', $server_result->getChat()->getUserName());
+        $this->assertEquals('1441378360', $server_result->getDate());
+        $this->assertEquals('hello', $server_result->getText());
         //... they are not finished...
 
     }
@@ -79,16 +71,14 @@ class ServerResponseTest extends TestCase
     public function sendMessageFail()
     {
         return '{
-                "ok":false,
-                "error_code":400,
-                "description":"Error: Bad Request: wrong chat id"
-            }';
+            "ok":false,
+            "error_code":400,
+            "description":"Error: Bad Request: wrong chat id"
+        }';
     }
 
     public function testSendMessageFail() {
-
         $result = $this->sendMessageFail();
-
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
 
         $this->assertFalse($this->server->isOk());
@@ -97,15 +87,13 @@ class ServerResponseTest extends TestCase
         $this->assertEquals('Error: Bad Request: wrong chat id', $this->server->getDescription());
     }
 
-   public function setWebHookOk()
+   public function setWebhookOk()
     {
         return '{"ok":true,"result":true,"description":"Webhook was set"}';
     }
 
     public function testSetWebhookOk() {
-
         $result = $this->setWebhookOk();
-
         $this->server =  new ServerResponse(json_decode($result, true), 'testbot');
 
         $this->assertTrue($this->server->isOk());
@@ -114,20 +102,17 @@ class ServerResponseTest extends TestCase
         $this->assertEquals('Webhook was set', $this->server->getDescription());
     }
 
-    public function setWebHookFail()
+    public function setWebhookFail()
     {
         return '{
             "ok":false,
             "error_code":400,
             "description":"Error: Bad request: htttps:\/\/domain.host.org\/dir\/hook.php"
-            }';
+        }';
     }
 
-
     public function testSetWebhookFail() {
-
-        $result = $this->setWebHookFail();
-
+        $result = $this->setWebhookFail();
         $this->server =  new ServerResponse(json_decode($result, true), 'testbot');
 
         $this->assertFalse($this->server->isOk());
@@ -141,50 +126,55 @@ class ServerResponseTest extends TestCase
         return '{
             "ok":true,
             "result":[
-                {"update_id":123,
+                {
+                    "update_id":123,
                     "message":{
                         "message_id":90,
                         "from":{"id":123456789,"first_name":"John","username":"Mjohn"},
                         "chat":{"id":123456789,"first_name":"John","username":"Mjohn"},
                         "date":1441569067,
-                        "text":"\/start"}
+                        "text":"\/start"
+                    }
                 },
-                {"update_id":124,
+                {
+                    "update_id":124,
                     "message":{
                         "message_id":91,
                         "from":{"id":123456788,"first_name":"Patrizia","username":"Patry"},
                         "chat":{"id":123456788,"first_name":"Patrizia","username":"Patry"},
                         "date":1441569073,
-                        "text":"Hello!"}
-                    },
-                {"update_id":125,
+                        "text":"Hello!"
+                    }
+                },
+                {
+                    "update_id":125,
                     "message":{
                         "message_id":92,
                         "from":{"id":123456789,"first_name":"John","username":"MJohn"},
                         "chat":{"id":123456789,"first_name":"John","username":"MJohn"},
                         "date":1441569094,
-                        "text":"\/echo hello!"}
-                    },
-                {"update_id":126,
-                "message":{
-                    "message_id":93,
-                    "from":{"id":123456788,"first_name":"Patrizia","username":"Patry"},
-                    "chat":{"id":123456788,"first_name":"Patrizia","username":"Patry"},
-                    "date":1441569112,
-                    "text":"\/echo the best"
+                        "text":"\/echo hello!"
+                    }
+                },
+                {
+                    "update_id":126,
+                    "message":{
+                        "message_id":93,
+                        "from":{"id":123456788,"first_name":"Patrizia","username":"Patry"},
+                        "chat":{"id":123456788,"first_name":"Patrizia","username":"Patry"},
+                        "date":1441569112,
+                        "text":"\/echo the best"
                     }
                 }
             ]
         }';
     }
 
-
     public function testGetUpdatesArray() {
         $result = $this->getUpdatesArray();
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
 
         $this->assertCount(4, $this->server->getResult());
-
         $this->assertInstanceOf('\Longman\TelegramBot\Entities\Update', $this->server->getResult()[0]);
     }
 
@@ -193,10 +183,10 @@ class ServerResponseTest extends TestCase
         return '{"ok":true,"result":[]}';
     }
 
-
     public function testGetUpdatesEmpty() {
         $result = $this->getUpdatesEmpty();
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
+
         $this->assertNull($this->server->getResult());
     }
 
@@ -227,18 +217,20 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-
     public function testGetUserProfilePhotos()
     {
         $result = $this->getUserProfilePhotos();
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
+        $server_result = $this->server->getResult();
+        $photos = $server_result->getPhotos();
 
-        $this->assertCount(3, $this->server->getResult()->getPhotos());
-        $this->assertCount(3, $this->server->getResult()->getPhotos()[0]);
-        $this->assertInstanceOf('\Longman\TelegramBot\Entities\UserProfilePhotos', $this->server->getResult());
+        //Photo count
+        $this->assertCount(3, $photos);
+        //Photo size count
+        $this->assertCount(3, $photos[0]);
 
-        $this->assertInstanceOf('\Longman\TelegramBot\Entities\PhotoSize', $this->server->getResult()->getPhotos()[0][0]);
-
+        $this->assertInstanceOf('\Longman\TelegramBot\Entities\UserProfilePhotos', $server_result);
+        $this->assertInstanceOf('\Longman\TelegramBot\Entities\PhotoSize', $photos[0][0]);
     }
 
     public function getFile()
@@ -253,16 +245,12 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-
     public function testGetFile()
     {
         $result = $this->getFile();
-        //print_r(json_decode($result, true));
         $this->server = new ServerResponse(json_decode($result, true), 'testbot');
-        //var_dump($this->server->getResult()->getPhotos());
 
         $this->assertInstanceOf('\Longman\TelegramBot\Entities\File', $this->server->getResult());
-
     }
 
     public function testSetGeneralTestFakeResponse() {
@@ -276,29 +264,29 @@ class ServerResponseTest extends TestCase
         $this->assertNull($this->server->getErrorCode());
         $this->assertEquals('', $this->server->getDescription());
 
-
         //sendMessage ok
         $fake_response = Request::generateGeneralFakeServerResponse(['chat_id' => 123456789, 'text' => 'hello']);
 
         $this->server =  new ServerResponse($fake_response, 'testbot');
+        $server_result = $this->server->getResult();
 
         $this->assertTrue($this->server->isOk());
-        $this->assertInstanceOf('\Longman\TelegramBot\Entities\Message', $this->server->getResult());
         $this->assertNull($this->server->getErrorCode());
         $this->assertNull($this->server->getDescription());
+        $this->assertInstanceOf('\Longman\TelegramBot\Entities\Message', $server_result);
 
         //Message
-        $this->assertEquals('1234', $this->server->getResult()->getMessageId());
-        $this->assertEquals('1441378360', $this->server->getResult()->getDate());
-        $this->assertEquals('hello', $this->server->getResult()->getText());
+        $this->assertEquals('1234', $server_result->getMessageId());
+        $this->assertEquals('1441378360', $server_result->getDate());
+        $this->assertEquals('hello', $server_result->getText());
         //Message //User
-        $this->assertEquals('123456789', $this->server->getResult()->getFrom()->getId());
-        $this->assertEquals('botname', $this->server->getResult()->getFrom()->getFirstName());
-        $this->assertEquals('namebot', $this->server->getResult()->getFrom()->getUserName());
+        $this->assertEquals('123456789', $server_result->getFrom()->getId());
+        $this->assertEquals('botname', $server_result->getFrom()->getFirstName());
+        $this->assertEquals('namebot', $server_result->getFrom()->getUserName());
         //Message //Chat
-        $this->assertEquals('123456789', $this->server->getResult()->getChat()->getId());
-        $this->assertEquals('', $this->server->getResult()->getChat()->getFirstName());
-        $this->assertEquals('', $this->server->getResult()->getChat()->getUserName());
+        $this->assertEquals('123456789', $server_result->getChat()->getId());
+        $this->assertEquals('', $server_result->getChat()->getFirstName());
+        $this->assertEquals('', $server_result->getChat()->getUserName());
 
         //... they are not finished...
     }

--- a/tests/Unit/Entities/ServerResponseTest.php
+++ b/tests/Unit/Entities/ServerResponseTest.php
@@ -18,15 +18,15 @@ use \Longman\TelegramBot\Request;
 
 /**
  * @package         TelegramTest
- * @author             Avtandil Kikabidze <akalongman@gmail.com>
- * @copyright         Avtandil Kikabidze <akalongman@gmail.com>
+ * @author          Avtandil Kikabidze <akalongman@gmail.com>
+ * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
  * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link             http://www.github.com/akalongman/php-telegram-bot
+ * @link            http://www.github.com/akalongman/php-telegram-bot
  */
 class ServerResponseTest extends TestCase
 {
     /**
-    * @var \Longman\TelegramBot\Telegram
+    * @var \Longman\TelegramBot\Entities\ServerResponse
     */
     private $server;
 

--- a/tests/Unit/Entities/UpdateTest.php
+++ b/tests/Unit/Entities/UpdateTest.php
@@ -26,7 +26,7 @@ class UpdateTest extends TestCase
     */
     private $update;
 
-    public function testUpdateCast() 
+    public function testUpdateCast()
     {
         $json = '
 {"update_id":137809336,
@@ -35,8 +35,7 @@ class UpdateTest extends TestCase
         $struct = json_decode($json, true);
         $update = new Update($struct, 'mybot');
 
-        $array_string_after = json_decode($update->toJSON(), true);
+        $array_string_after = json_decode($update->toJson(), true);
         $this->assertEquals($struct, $array_string_after);
-
     }
 }

--- a/tests/Unit/Entities/UpdateTest.php
+++ b/tests/Unit/Entities/UpdateTest.php
@@ -26,10 +26,6 @@ class UpdateTest extends TestCase
     */
     private $update;
 
-    /**
-     * @test
-     */
-
     public function testUpdateCast() 
     {
         $json = '

--- a/tests/Unit/Entities/UpdateTest.php
+++ b/tests/Unit/Entities/UpdateTest.php
@@ -13,16 +13,16 @@ namespace Tests\Unit;
 use \Longman\TelegramBot\Entities\Update;
 
 /**
- * @package 		TelegramTest
- * @author 		Avtandil Kikabidze <akalongman@gmail.com>
- * @copyright 		Avtandil Kikabidze <akalongman@gmail.com>
- * @license 		http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link 			http://www.github.com/akalongman/php-telegram-bot
+ * @package         TelegramTest
+ * @author          Avtandil Kikabidze <akalongman@gmail.com>
+ * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
+ * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
+ * @link            http://www.github.com/akalongman/php-telegram-bot
  */
 class UpdateTest extends TestCase
 {
     /**
-    * @var \Longman\TelegramBot\Telegram
+    * @var \Longman\TelegramBot\Entities\Update
     */
     private $update;
 

--- a/tests/Unit/TelegramLogTest.php
+++ b/tests/Unit/TelegramLogTest.php
@@ -56,35 +56,29 @@ class TelegramLogTest extends TestCase
     }
 
     /**
-     * @test
      * @expectedException \Longman\TelegramBot\Exception\TelegramLogException
      */
-    public function newInstanceWithoutErrorPath()
+    public function testNewInstanceWithoutErrorPath()
     {
         TelegramLog::initErrorLog('');
     }
 
     /**
-     * @test
      * @expectedException \Longman\TelegramBot\Exception\TelegramLogException
      */
-    public function newInstanceWithoutDebugPath()
+    public function testNewInstanceWithoutDebugPath()
     {
         TelegramLog::initDebugLog('');
     }
 
     /**
-     * @test
      * @expectedException \Longman\TelegramBot\Exception\TelegramLogException
      */
-    public function newInstanceWithoutUpdatePath()
+    public function testNewInstanceWithoutUpdatePath()
     {
         TelegramLog::initUpdateLog('');
     }
 
-    /**
-     * @test
-     */
     public function testErrorStream()
     {
         $file = $this->logfiles['error'];
@@ -95,9 +89,6 @@ class TelegramLogTest extends TestCase
         $this->assertContains('bot_log.ERROR: my error', file_get_contents($file));
     }
 
-    /**
-     * @test
-     */
     public function testDebugStream()
     {
         $file = $this->logfiles['debug'];
@@ -108,9 +99,6 @@ class TelegramLogTest extends TestCase
         $this->assertContains('bot_log.DEBUG: my debug', file_get_contents($file));
     }
 
-    /**
-     * @test
-     */
     public function testUpdateStream()
     {
         $file = $this->logfiles['update'];
@@ -121,9 +109,6 @@ class TelegramLogTest extends TestCase
         $this->assertContains('my update', file_get_contents($file));
     }
 
-    /**
-     * @test
-     */
     public function testExternalStream()
     {
         $file = $this->logfiles['external'];

--- a/tests/Unit/TelegramLogTest.php
+++ b/tests/Unit/TelegramLogTest.php
@@ -26,7 +26,7 @@ use Tests\TestHelpers;
 class TelegramLogTest extends TestCase
 {
     /**
-     * Logfile paths
+     * @var array Dummy logfile paths
      */
     private $logfiles = [
         'error'    => '/tmp/errorlog.log',

--- a/tests/Unit/TelegramLogTest.php
+++ b/tests/Unit/TelegramLogTest.php
@@ -29,10 +29,10 @@ class TelegramLogTest extends TestCase
      * @var array Dummy logfile paths
      */
     private $logfiles = [
-        'error'    => '/tmp/errorlog.log',
-        'debug'    => '/tmp/debuglog.log',
-        'update'   => '/tmp/updatelog.log',
-        'external' => '/tmp/externallog.log',
+        'error'    => '/tmp/php-telegram-bot-errorlog.log',
+        'debug'    => '/tmp/php-telegram-bot-debuglog.log',
+        'update'   => '/tmp/php-telegram-bot-updatelog.log',
+        'external' => '/tmp/php-telegram-bot-externallog.log',
     ];
 
     /**
@@ -82,37 +82,37 @@ class TelegramLogTest extends TestCase
     public function testErrorStream()
     {
         $file = $this->logfiles['error'];
-        $this->assertFalse(file_exists($file));
+        $this->assertFileNotExists($file);
         TelegramLog::initErrorLog($file);
         TelegramLog::error('my error');
-        $this->assertTrue(file_exists($file));
+        $this->assertFileExists($file);
         $this->assertContains('bot_log.ERROR: my error', file_get_contents($file));
     }
 
     public function testDebugStream()
     {
         $file = $this->logfiles['debug'];
-        $this->assertFalse(file_exists($file));
+        $this->assertFileNotExists($file);
         TelegramLog::initDebugLog($file);
         TelegramLog::debug('my debug');
-        $this->assertTrue(file_exists($file));
+        $this->assertFileExists($file);
         $this->assertContains('bot_log.DEBUG: my debug', file_get_contents($file));
     }
 
     public function testUpdateStream()
     {
         $file = $this->logfiles['update'];
-        $this->assertFalse(file_exists($file));
+        $this->assertFileNotExists($file);
         TelegramLog::initUpdateLog($file);
         TelegramLog::update('my update');
-        $this->assertTrue(file_exists($file));
+        $this->assertFileExists($file);
         $this->assertContains('my update', file_get_contents($file));
     }
 
     public function testExternalStream()
     {
         $file = $this->logfiles['external'];
-        $this->assertFalse(file_exists($file));
+        $this->assertFileNotExists($file);
 
         $external_monolog = new Logger('bot_update_log');
         $external_monolog->pushHandler(new StreamHandler($file, Logger::ERROR));
@@ -122,7 +122,7 @@ class TelegramLogTest extends TestCase
         TelegramLog::error('my error');
         TelegramLog::debug('my debug');
 
-        $this->assertTrue(file_exists($file));
+        $this->assertFileExists($file);
         $file_contents = file_get_contents($file);
         $this->assertContains('bot_update_log.ERROR: my error', $file_contents);
         $this->assertContains('bot_update_log.DEBUG: my debug', $file_contents);

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -60,43 +60,32 @@ class TelegramTest extends TestCase
     }
 
     /**
-     * @test
      * @expectedException \Longman\TelegramBot\Exception\TelegramException
      */
-    public function newInstanceWithoutApiKeyParam()
+    public function testNewInstanceWithoutApiKeyParam()
     {
         new Telegram(null, 'testbotname');
     }
 
     /**
-     * @test
      * @expectedException \Longman\TelegramBot\Exception\TelegramException
      */
-    public function newInstanceWithoutBotNameParam()
+    public function testNewInstanceWithoutBotNameParam()
     {
         new Telegram('testapikey', null);
     }
 
-    /**
-     * @test
-     */
-    public function getApiKey()
+    public function testGetApiKey()
     {
         $this->assertEquals('testapikey', $this->telegram->getApiKey());
     }
 
-    /**
-     * @test
-     */
-    public function getBotName()
+    public function testGetBotName()
     {
         $this->assertEquals('testbotname', $this->telegram->getBotName());
     }
 
-    /**
-     * @test
-     */
-    public function enableAdmins()
+    public function testEnableAdmins()
     {
         $tg = &$this->telegram;
 
@@ -115,10 +104,7 @@ class TelegramTest extends TestCase
         $this->assertCount(3, $tg->getAdminList());
     }
 
-    /**
-     * @test
-     */
-    public function addCustomCommandsPaths()
+    public function testAddCustomCommandsPaths()
     {
         $tg = &$this->telegram;
 
@@ -140,20 +126,14 @@ class TelegramTest extends TestCase
         $this->assertAttributeCount(4, 'commands_paths', $tg);
     }
 
-    /**
-     * @test
-     */
-    public function getCommandsList()
+    public function testGetCommandsList()
     {
         $commands = $this->telegram->getCommandsList();
         $this->assertInternalType('array', $commands);
         $this->assertNotCount(0, $commands);
     }
 
-    /**
-     * @test
-     */
-    public function getHelpCommandObject()
+    public function testGetHelpCommandObject()
     {
         $command = $this->telegram->getCommandObject('help');
         $this->assertInstanceOf('Longman\TelegramBot\Commands\UserCommands\HelpCommand', $command);

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -40,7 +40,7 @@ class TelegramTest extends TestCase
     */
     protected function setUp()
     {
-        $this->telegram = new Telegram('testapikey', 'testbotname');
+        $this->telegram = new Telegram('apikey', 'testbot');
 
         // Create a few custom commands paths.
         foreach ($this->custom_commands_paths as $custom_path) {
@@ -64,7 +64,7 @@ class TelegramTest extends TestCase
      */
     public function testNewInstanceWithoutApiKeyParam()
     {
-        new Telegram(null, 'testbotname');
+        new Telegram(null, 'testbot');
     }
 
     /**
@@ -72,17 +72,17 @@ class TelegramTest extends TestCase
      */
     public function testNewInstanceWithoutBotNameParam()
     {
-        new Telegram('testapikey', null);
+        new Telegram('apikey', null);
     }
 
     public function testGetApiKey()
     {
-        $this->assertEquals('testapikey', $this->telegram->getApiKey());
+        $this->assertEquals('apikey', $this->telegram->getApiKey());
     }
 
     public function testGetBotName()
     {
-        $this->assertEquals('testbotname', $this->telegram->getBotName());
+        $this->assertEquals('testbot', $this->telegram->getBotName());
     }
 
     public function testEnableAdmins()

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -27,7 +27,7 @@ class TelegramTest extends TestCase
     private $telegram;
 
     /**
-     * @var array
+     * @var array A few dummy custom commands paths
      */
     private $custom_commands_paths = [
         '/tmp/php-telegram-bot-custom-commands-1',

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -42,7 +42,7 @@ class TelegramTest extends TestCase
     {
         $this->telegram = new Telegram('apikey', 'testbot');
 
-        // Create a few custom commands paths.
+        // Create a few dummy custom commands paths.
         foreach ($this->custom_commands_paths as $custom_path) {
             mkdir($custom_path);
         }
@@ -87,7 +87,7 @@ class TelegramTest extends TestCase
 
     public function testEnableAdmins()
     {
-        $tg = &$this->telegram;
+        $tg = $this->telegram;
 
         $this->assertEmpty($tg->getAdminList());
 
@@ -106,7 +106,7 @@ class TelegramTest extends TestCase
 
     public function testAddCustomCommandsPaths()
     {
-        $tg = &$this->telegram;
+        $tg = $this->telegram;
 
         $this->assertAttributeCount(1, 'commands_paths', $tg);
 

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -14,7 +14,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 {
     protected function skip64BitTest()
     {
-        if (PHP_INT_SIZE == 4) {
+        if (PHP_INT_SIZE === 4) {
             $this->markTestSkipped(
                 'Skipping test that can run only on a 64-bit build of PHP.'
             );


### PR DESCRIPTION
This PR now allows for local database tests to be configurable. Check the new constants in `phpunit.xml.dist`. Just copy it to `phpunit.xml` and adjust values to your local test environment.

A bunch of DocBlock fixes and test renames.
Also makes more use of TestHelpers class to facilitate entity testing.