### PR TITLE
Improved InlineKeyboardButton

### DIFF
--- a/src/Entities/InlineKeyboardButton.php
+++ b/src/Entities/InlineKeyboardButton.php
@@ -18,14 +18,13 @@ class InlineKeyboardButton extends Entity
     protected $url;
     protected $callback_data;
     protected $switch_inline_query;
-
+    private $hasOption = false;
 
     /**
      * InlineKeyboardButton constructor.
      *
-     * @todo check if only one of 'url, callback_data, switch_inline_query' fields is set, documentation states that only one of these can be used
-     *
      * @param array $data
+     * @throws TelegramException
      */
     public function __construct($data = array())
     {
@@ -34,11 +33,21 @@ class InlineKeyboardButton extends Entity
             throw new TelegramException('text is empty!');
         }
 
-        $this->url = isset($data['url']) ? $data['url'] : null;
-        $this->callback_data = isset($data['callback_data']) ? $data['callback_data'] : null;
-        $this->switch_inline_query = isset($data['switch_inline_query']) ? $data['switch_inline_query'] : null;
+        if (isset($data['url']) and !empty($data['url'])) {
+            $this->url = $data['url'];
+            $this->hasOption = true;
+        }
 
-        if ($this->url === '' && $this->callback_data === '' && $this->switch_inline_query === '') {
+        if (!$this->hasOption and (isset($data['callback_data']) and !empty($data['callback_data']))) {
+            $this->callback_data = $data['callback_data'];
+            $this->isSetOption = true;
+        }
+
+        if (!$this->hasOption and (isset($data['switch_inline_query']) and !empty($data['switch_inline_query']))) {
+            $this->switch_inline_query = $data['switch_inline_query'];
+        }
+
+        if (!$this->url && !$this->callback_data && !$this->switch_inline_query) {
             throw new TelegramException('You must use at least one of these fields: url, callback_data, switch_inline_query!');
         }
     }


### PR DESCRIPTION
Fixed TODO in InlineKeyboardButton:
check if only one of 'url, callback_data, switch_inline_query' fields is set, documentation states that only one of these can be used