### PR TITLE
fix enableAdmins()

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -467,7 +467,7 @@ class Telegram
      */
     public function enableAdmin($admin_id)
     {
-        if (is_int($admin_id) && $admin_id > 0 && !in_array($admin_id, $this->admins_list)) {
+        if (is_numeric($admin_id) && !is_float($admin_id) && $admin_id > 0 && !in_array($admin_id, $this->admins_list)) {
             $this->admins_list[] = $admin_id;
         } else {
             TelegramLog::error('Invalid value "' . $admin_id . '" for admin.');


### PR DESCRIPTION
Basically for me ```$telegram->enableAdmins(['xxxxxxxxxx']);``` doesn't work, admins_list array remains empty, it returns ```'Invalid value xxxxxxxxxx for admin.'``` error instead.

It seems like on my webhost my id isn't considered int, some systems might limit max int value and I guess thats what happens in my case... it's only weird that my webhosts limits it at length = 10.
I guess is_numeric + !is_float combo is good replacement here?
