### PR TITLE
fix constraint error

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -895,7 +895,7 @@ class DB
         self::insertUser($from, $edit_date, $chat);
 
         try {
-            $sth = self::$pdo->prepare('INSERT INTO `' . TB_EDITED_MESSAGE . '`
+            $sth = self::$pdo->prepare('INSERT IGNORE INTO `' . TB_EDITED_MESSAGE . '`
                 (
                 `chat_id`, `message_id`, `user_id`, `edit_date`, `text`, `entities`, `caption`
                 )


### PR DESCRIPTION
In case user spams inline keyboard button it will create a duplicated query which will produce constraint error, adding 'IGNORE' to the query shall fix this, it was general mistake of mine to not add it in the first place because other queries have eithier IGNORE or KEY UPDATE in the queries.