### PR TITLE
Use PSR-7 stream as file source

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -181,7 +181,7 @@ class Request
         //Check for resources in data
         $contains_resource = false;
         foreach ($data as $item) {
-            if (is_resource($item)) {
+            if ((is_resource($item)) || ($item instanceof \GuzzleHttp\Psr7\Stream)) {
                 $contains_resource = true;
                 break;
             }


### PR DESCRIPTION
Makes possible to send all kind of files from memory, not from file on disk by usage of PSR-7 streams.

All we need is to create PSR-7 stream and pass it as a part of $data to any of sendXXXX method InputFile is allowed for by Bot API. The patch fixes exec method to handle request as multipart for both cases: file resource and stream.

The key should be set in accordance to the API call type: 'document', 'photo', 'audio', e.t.c.

PSR-7 metadata 'uri' must contain filename.

Code example:

    $stream = \GuzzleHttp\Psr7\stream_for( 'File contents here!', [ 'metadata' =>['uri'=>'filename.ext']]);

    $data = [];
    $data['chat_id'] = $chat_id;
    $data['caption'] = $caption;
    $data['document'] = $stream;
            
    Request::sendDocument($data);

The example will send as document the file named 'filename.ext' containing 'File contents here!'.