### PR TITLE
Fix GitHub templates to prevent mistakes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,13 +8,13 @@
 - RAW update (if available):
 
 ### Expected behaviour
-> What SHOULD be happening?
+<!-- What SHOULD be happening? -->
 
 ### Actual behaviour
-> What IS happening?
+<!-- What IS happening? -->
 
 ### Steps to reproduce
-> Explain how to reproduce the issue
+<!-- Explain how to reproduce the issue -->
 
 ### Extra details
-> Please post any extra details that might help solve the issue (e.g. logs)
+<!-- Please post any extra details that might help solve the issue (e.g. logs) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-> Make sure this pull request is pointed towards the "develop" branch!
+<!-- Make sure this pull request is pointed towards the "develop" branch! -->
 
-> Explain in detail what this pull request contains.
+<!-- Explain in detail what this pull request contains. -->


### PR DESCRIPTION
Turn quotes into hidden HTML tags to prevent them from being posted by mistake.