### PR TITLE
Update webhookinfo entity with the latest additions by Telegram.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ try {
     $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
 
     // Set webhook
-    $result = $telegram->setWebHook($hook_url);
+    $result = $telegram->setWebhook($hook_url);
     if ($result->isOk()) {
         echo $result->getDescription();
     }
@@ -242,7 +242,7 @@ try {
 
 To upload the certificate, add the certificate path as a parameter in *set.php*:
 ```php
-$result = $telegram->setWebHook($hook_url, $certificate_path);
+$result = $telegram->setWebhook($hook_url, ['certificate' => $certificate_path]);
 ```
 
 ### Unset Webhook

--- a/examples/set.php
+++ b/examples/set.php
@@ -10,10 +10,10 @@ try {
     $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
 
     // Set webhook
-    $result = $telegram->setWebHook($hook_url);
+    $result = $telegram->setWebhook($hook_url);
 
     // Uncomment to use certificate
-    //$result = $telegram->setWebHook($hook_url, $path_certificate);
+    //$result = $telegram->setWebhook($hook_url, ['certificate' => $path_certificate]);
 
     if ($result->isOk()) {
         echo $result->getDescription();

--- a/examples/unset.php
+++ b/examples/unset.php
@@ -9,7 +9,7 @@ try {
     $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
 
     // Unset webhook
-    $result = $telegram->unsetWebHook();
+    $result = $telegram->unsetWebhook();
 
     if ($result->isOk()) {
         echo $result->getDescription();

--- a/src/Entities/WebhookInfo.php
+++ b/src/Entities/WebhookInfo.php
@@ -15,12 +15,13 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#webhookinfo
  *
- * @method string getUrl()                  Webhook URL, may be empty if webhook is not set up
- * @method bool   getHasCustomCertificate() True, if a custom certificate was provided for webhook certificate checks
- * @method int    getPendingUpdateCount()   Number of updates awaiting delivery
- * @method int    getLastErrorDate()        Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook
- * @method string getLastErrorMessage()     Optional. Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook
- *
+ * @method string   getUrl()                  Webhook URL, may be empty if webhook is not set up
+ * @method bool     getHasCustomCertificate() True, if a custom certificate was provided for webhook certificate checks
+ * @method int      getPendingUpdateCount()   Number of updates awaiting delivery
+ * @method int      getLastErrorDate()        Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook
+ * @method string   getLastErrorMessage()     Optional. Error message in human-readable format for the most recent error that happened when trying to deliver an update via webhook
+ * @method int      getMaxConnections()       Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
+ * @method string[] getAllowedUpdates()       Optional. A list of update types the bot is subscribed to. Defaults to all update types
  */
 class WebhookInfo extends Entity
 {

--- a/src/Request.php
+++ b/src/Request.php
@@ -800,16 +800,23 @@ class Request
      * @link https://core.telegram.org/bots/api#setwebhook
      *
      * @param string $url
-     * @param string $file
+     * @param array  $data Optional parameters.
      *
      * @return \Longman\TelegramBot\Entities\ServerResponse
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public static function setWebhook($url = '', $file = null)
+    public static function setWebhook($url = '', array $data = [])
     {
-        $data = ['url' => $url];
+        $data = array_intersect_key($data, array_flip([
+            'certificate',
+            'max_connections',
+            'allowed_updates',
+        ]));
+        $data['url'] = $url;
 
-        self::assignEncodedFile($data, 'certificate', $file);
+        if (isset($data['certificate'])) {
+            self::assignEncodedFile($data, 'certificate', $data['certificate']);
+        }
 
         return self::send('setWebhook', $data);
     }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -727,19 +727,19 @@ class Telegram
     /**
      * Set Webhook for bot
      *
-     * @param string      $url
-     * @param string|null $path_certificate
+     * @param string $url
+     * @param array  $data Optional parameters.
      *
      * @return \Longman\TelegramBot\Entities\ServerResponse
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function setWebHook($url, $path_certificate = null)
+    public function setWebhook($url, array $data = [])
     {
         if (empty($url)) {
             throw new TelegramException('Hook url is empty!');
         }
 
-        $result = Request::setWebhook($url, $path_certificate);
+        $result = Request::setWebhook($url, $data);
 
         if (!$result->isOk()) {
             throw new TelegramException(
@@ -756,7 +756,7 @@ class Telegram
      * @return mixed
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function unsetWebHook()
+    public function unsetWebhook()
     {
         $result = Request::setWebhook();
 

--- a/tests/unit/Entities/WebhookInfoTest.php
+++ b/tests/unit/Entities/WebhookInfoTest.php
@@ -21,155 +21,109 @@ use Longman\TelegramBot\Entities\WebhookInfo;
  */
 class WebhookInfoTest extends TestCase
 {
-    
-   /**
-    * webhook data
-    *
-    * @var array
-    *
-    */
+    /**
+     * @var array Webhook data
+     */
     public $data;
 
-   /**
-    *
-    * Set Up
-    *
-    */
     public function setUp()
     {
         $this->data = [
-            'url'   => 'http://phpunit',
-            'has_custom_certificate' => (bool)mt_rand(0, 1),
-            'pending_update_count'   => (int)mt_rand(1, 9),
+            'url'                    => 'http://phpunit',
+            'has_custom_certificate' => (bool) mt_rand(0, 1),
+            'pending_update_count'   => (int) mt_rand(1, 9),
             'last_error_date'        => time(),
-            'last_error_message'     => 'Same_error_message'
+            'last_error_message'     => 'Some_error_message',
+            'max_connections'        => (int) mt_rand(1, 100),
+            'allowed_updates'        => ['message', 'edited_channel_post', 'callback_query'],
         ];
     }
 
-   /**
-    *
-    * TearDown 
-    *
-    */
-    public function tearDown()
-    {
-        //pass
-    }
-
-   /**
-    *
-    * Testing base stage with data object creating
-    *
-    */
     public function testBaseStageWebhookInfo()
     {
         $webhook = new WebhookInfo($this->data);
         $this->assertInstanceOf('Longman\TelegramBot\Entities\WebhookInfo', $webhook);
     }
 
-    /**
-    *
-    * Testing getUrl
-    *
-    */
     public function testGetUrl()
     {
         $webhook = new WebhookInfo($this->data);
-        $url = $webhook->getUrl();
+        $url     = $webhook->getUrl();
         $this->assertEquals($this->data['url'], $url);
     }
-    
-   /**
-    *
-    * Testing getHasCustomCertificate
-    *
-    */
+
     public function testGetHasCustomCertificate()
     {
-        $webhook = new WebhookInfo($this->data);
+        $webhook            = new WebhookInfo($this->data);
         $custom_certificate = $webhook->getHasCustomCertificate();
         $this->assertInternalType('bool', $custom_certificate);
         $this->assertEquals($this->data['has_custom_certificate'], $custom_certificate);
     }
 
-   /**
-    *
-    * Testing getPendingUpdateCount
-    *
-    */
     public function testGetPendingUpdateCount()
     {
-        $webhook = new WebhookInfo($this->data);
+        $webhook      = new WebhookInfo($this->data);
         $update_count = $webhook->getPendingUpdateCount();
         $this->assertInternalType('int', $update_count);
         $this->assertEquals($this->data['pending_update_count'], $update_count);
-    } 
+    }
 
-   /**
-    *
-    * Testing getLastErrorDate
-    *
-    */
     public function testGetLastErrorDate()
     {
-        $webhook = new WebhookInfo($this->data);
+        $webhook    = new WebhookInfo($this->data);
         $error_date = $webhook->getLastErrorDate();
         $this->assertInternalType('int', $error_date);
-        #$this->assertRegExp('/([0-9]{10,})/', $error_date);
         $this->assertEquals($this->data['last_error_date'], $error_date);
     }
 
-    /**
-    *
-    * Testing getLastErrorMessage
-    *
-    */
     public function testGetLastErrorMessage()
     {
-        $webhook = new WebhookInfo($this->data);
+        $webhook   = new WebhookInfo($this->data);
         $error_msg = $webhook->getLastErrorMessage();
-        $this->assertInternalType('string', $error_msg, $error_msg);
+        $this->assertInternalType('string', $error_msg);
         $this->assertEquals($this->data['last_error_message'], $error_msg);
     }
 
-    /**
-    * 
-    * Testing get data without params
-    *
-    */
+    public function testGetMaxConnections()
+    {
+        $webhook         = new WebhookInfo($this->data);
+        $max_connections = $webhook->getMaxConnections();
+        $this->assertInternalType('int', $max_connections);
+        $this->assertEquals($this->data['max_connections'], $max_connections);
+    }
+
+    public function testGetAllowedUpdates()
+    {
+        $webhook         = new WebhookInfo($this->data);
+        $allowed_updates = $webhook->getAllowedUpdates();
+        $this->assertInternalType('array', $allowed_updates);
+        $this->assertEquals($this->data['allowed_updates'], $allowed_updates);
+    }
+
     public function testGetDataWithoutParams()
     {
-        unset($this->data['url']);
-        $webhook = new WebhookInfo($this->data);
-        $result = $webhook->getUrl();
-        $this->assertNull($result);
+        // Make a copy to not risk failed tests if not run in proper order.
+        $data = $this->data;
 
-        unset($webhook, $result);
+        unset($data['url']);
+        $this->assertNull((new WebhookInfo($data))->getUrl());
 
-        unset($this->data['has_custom_certificate']);        
-        $webhook = new WebhookInfo($this->data);
-        $result = $webhook->getHasCustomCertificate();
-        $this->assertNull($result);
+        unset($data['has_custom_certificate']);
+        $this->assertNull((new WebhookInfo($data))->getHasCustomCertificate());
 
-        unset($webhook, $result);
+        unset($data['pending_update_count']);
+        $this->assertNull((new WebhookInfo($data))->getPendingUpdateCount());
 
-        unset($this->data['pending_update_count']);
-        $webhook = new WebhookInfo($this->data);
-        $result = $webhook->getPendingUpdateCount();
-        $this->assertNull($result);
-        
-        unset($webhook, $result);
+        unset($data['last_error_date']);
+        $this->assertNull((new WebhookInfo($data))->getLastErrorDate());
 
-        unset($this->data['last_error_date']);
-        $webhook = new WebhookInfo($this->data);
-        $result = $webhook->getLastErrorDate();
-        $this->assertNull($result);
+        unset($data['last_error_message']);
+        $this->assertNull((new WebhookInfo($data))->getLastErrorMessage());
 
-        unset($webhook, $result);
+        unset($data['max_connections']);
+        $this->assertNull((new WebhookInfo($data))->getMaxConnections());
 
-        unset($this->data['last_error_message']);
-        $webhook = new WebhookInfo($this->data);
-        $result = $webhook->getLastErrorMessage();
-        $this->assertNull($result);
+        unset($data['allowed_updates']);
+        $this->assertNull((new WebhookInfo($data))->getAllowedUpdates());
     }
 }


### PR DESCRIPTION
Update setWebhook to allow passing of new arguments.

**This change breaks backwards compatibility!**

Fix #345 