### PR TITLE
Use new deleteWebhook method to delete a webhook.

### DIFF
--- a/examples/unset.php
+++ b/examples/unset.php
@@ -8,8 +8,8 @@ try {
     // Create Telegram API object
     $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
 
-    // Unset webhook
-    $result = $telegram->unsetWebhook();
+    // Delete webhook
+    $result = $telegram->deleteWebhook();
 
     if ($result->isOk()) {
         echo $result->getDescription();

--- a/src/Request.php
+++ b/src/Request.php
@@ -54,6 +54,7 @@ class Request
     private static $actions = [
         'getUpdates',
         'setWebhook',
+        'deleteWebhook',
         'getMe',
         'sendMessage',
         'forwardMessage',
@@ -282,7 +283,7 @@ class Request
     {
         $fp = fopen($file, 'r');
         if ($fp === false) {
-            throw new TelegramException('Cannot open ' . $file . ' for reading');
+            throw new TelegramException('Cannot open "' . $file . '" for reading');
         }
 
         return $fp;
@@ -346,7 +347,7 @@ class Request
     private static function ensureValidAction($action)
     {
         if (!in_array($action, self::$actions, true)) {
-            throw new TelegramException('The action " . $action . " doesn\'t exist!');
+            throw new TelegramException('The action "' . $action . '" doesn\'t exist!');
         }
     }
 
@@ -398,7 +399,7 @@ class Request
         do {
             //Chop off and send the first message
             $data['text'] = mb_substr($text, 0, 4096);
-            $response = self::send('sendMessage', $data);
+            $response     = self::send('sendMessage', $data);
 
             //Prepare the next message
             $text = mb_substr($text, 4096);
@@ -807,7 +808,7 @@ class Request
      */
     public static function setWebhook($url = '', array $data = [])
     {
-        $data = array_intersect_key($data, array_flip([
+        $data        = array_intersect_key($data, array_flip([
             'certificate',
             'max_connections',
             'allowed_updates',
@@ -819,6 +820,20 @@ class Request
         }
 
         return self::send('setWebhook', $data);
+    }
+
+    /**
+     * Delete webhook
+     *
+     * @link https://core.telegram.org/bots/api#deletewebhook
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public static function deleteWebhook()
+    {
+        // Must send some arbitrary data for this to work for now...
+        return self::send('deleteWebhook', ['delete']);
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -753,18 +753,31 @@ class Telegram
     }
 
     /**
-     * Unset Webhook for bot
+     * Deprecated alias for deleteWebhook
+     *
+     * This is kept for backwards compatibility!
      *
      * @return mixed
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
     public function unsetWebhook()
     {
-        $result = Request::setWebhook();
+        return $this->deleteWebhook();
+    }
+
+    /**
+     * Delete any assigned webhook
+     *
+     * @return mixed
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public function deleteWebhook()
+    {
+        $result = Request::deleteWebhook();
 
         if (!$result->isOk()) {
             throw new TelegramException(
-                'Webhook was not unset! Error: ' . $result->getErrorCode() . ' ' . $result->getDescription()
+                'Webhook was not deleted! Error: ' . $result->getErrorCode() . ' ' . $result->getDescription()
             );
         }
 


### PR DESCRIPTION
Fix some error outputs.

For the moment, this PR keeps the `unsetWebhook` method in place for backwards compatibility.