### PR TITLE
Fix self-signed certificate usage

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -183,6 +183,7 @@ class Request
         //Reformat data array in multipart way if it contains a resource
         foreach ($data as $key => $item) {
             $has_resource |= is_resource($item);
+            is_array($item) && $item = json_encode($item);
             $multipart[] = ['name' => $key, 'contents' => $item];
         }
         if ($has_resource) {


### PR DESCRIPTION
Guzzle uses a multipart stream, which doesn't allow arrays, so they need to be encoded to JSON first.

Props @jacklul