### PR TITLE
Implement new api changes

### DIFF
--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -50,6 +50,7 @@ class CallbackqueryCommand extends SystemCommand
             'callback_query_id' => $callback_query_id,
             'text'              => 'Hello World!',
             'show_alert'        => $callback_data === 'thumb up',
+            'cache_time'        => 5,
         ];
 
         return Request::answerCallbackQuery($data);

--- a/src/DB.php
+++ b/src/DB.php
@@ -406,20 +406,22 @@ class DB
             return false;
         }
 
-        $chat_id    = $chat->getId();
-        $chat_title = $chat->getTitle();
-        $chat_type  = $chat->getType();
+        $chat_id                             = $chat->getId();
+        $chat_title                          = $chat->getTitle();
+        $chat_type                           = $chat->getType();
+        $chat_all_members_are_administrators = $chat->getAllMembersAreAdministrators();
 
         try {
             $sth = self::$pdo->prepare('
-                INSERT INTO `' . TB_CHAT . '`
-                (`id`, `type`, `title`, `created_at` ,`updated_at`, `old_id`)
+                INSERT IGNORE INTO `' . TB_CHAT . '`
+                (`id`, `type`, `title`, `all_members_are_administrators`, `created_at` ,`updated_at`, `old_id`)
                 VALUES
-                (:id, :type, :title, :date, :date, :oldid)
+                (:id, :type, :title, :all_members_are_administrators, :date, :date, :oldid)
                 ON DUPLICATE KEY UPDATE
-                    `type`       = :type,
-                    `title`      = :title,
-                    `updated_at` = :date
+                    `type`                           = :type,
+                    `title`                          = :title,
+                    `all_members_are_administrators` = :all_members_are_administrators,
+                    `updated_at`                     = :date
             ');
 
             if ($migrate_to_chat_id) {
@@ -434,6 +436,7 @@ class DB
 
             $sth->bindParam(':type', $chat_type, PDO::PARAM_INT);
             $sth->bindParam(':title', $chat_title, PDO::PARAM_STR, 255);
+            $sth->bindParam(':all_members_are_administrators', $chat_all_members_are_administrators, PDO::PARAM_INT);
             $sth->bindParam(':date', $date, PDO::PARAM_STR);
 
             return $sth->execute();

--- a/src/DB.php
+++ b/src/DB.php
@@ -733,14 +733,15 @@ class DB
 
         $date = self::getTimestamp($message->getDate());
 
-        $forward_from       = $message->getForwardFrom();
-        $forward_from_chat  = $message->getForwardFromChat();
-        $photo              = self::entitiesArrayToJson($message->getPhoto(), '');
-        $entities           = self::entitiesArrayToJson($message->getEntities(), null);
-        $new_chat_member    = $message->getNewChatMember();
-        $new_chat_photo     = self::entitiesArrayToJson($message->getNewChatPhoto(), '');
-        $left_chat_member   = $message->getLeftChatMember();
-        $migrate_to_chat_id = $message->getMigrateToChatId();
+        $forward_from            = $message->getForwardFrom();
+        $forward_from_chat       = $message->getForwardFromChat();
+        $forward_from_message_id = $message->getForwardFromMessageId();
+        $photo                   = self::entitiesArrayToJson($message->getPhoto(), '');
+        $entities                = self::entitiesArrayToJson($message->getEntities(), null);
+        $new_chat_member         = $message->getNewChatMember();
+        $new_chat_photo          = self::entitiesArrayToJson($message->getNewChatPhoto(), '');
+        $left_chat_member        = $message->getLeftChatMember();
+        $migrate_to_chat_id      = $message->getMigrateToChatId();
 
         //Insert chat, update chat id in case it migrated
         self::insertChat($chat, $date, $migrate_to_chat_id);
@@ -778,7 +779,7 @@ class DB
             $sth = self::$pdo->prepare('
                 INSERT IGNORE INTO `' . TB_MESSAGE . '`
                 (
-                    `id`, `user_id`, `chat_id`, `date`, `forward_from`, `forward_from_chat`,
+                    `id`, `user_id`, `chat_id`, `date`, `forward_from`, `forward_from_chat`, `forward_from_message_id`,
                     `forward_date`, `reply_to_chat`, `reply_to_message`, `text`, `entities`, `audio`, `document`,
                     `photo`, `sticker`, `video`, `voice`, `caption`, `contact`,
                     `location`, `venue`, `new_chat_member`, `left_chat_member`,
@@ -786,7 +787,7 @@ class DB
                     `supergroup_chat_created`, `channel_chat_created`,
                     `migrate_from_chat_id`, `migrate_to_chat_id`, `pinned_message`
                 ) VALUES (
-                    :message_id, :user_id, :chat_id, :date, :forward_from, :forward_from_chat,
+                    :message_id, :user_id, :chat_id, :date, :forward_from, :forward_from_chat, :forward_from_message_id,
                     :forward_date, :reply_to_chat, :reply_to_message, :text, :entities, :audio, :document,
                     :photo, :sticker, :video, :voice, :caption, :contact,
                     :location, :venue, :new_chat_member, :left_chat_member,
@@ -838,6 +839,7 @@ class DB
             $sth->bindParam(':date', $date, PDO::PARAM_STR);
             $sth->bindParam(':forward_from', $forward_from, PDO::PARAM_INT);
             $sth->bindParam(':forward_from_chat', $forward_from_chat, PDO::PARAM_INT);
+            $sth->bindParam(':forward_from_message_id', $forward_from_message_id, PDO::PARAM_INT);
             $sth->bindParam(':forward_date', $forward_date, PDO::PARAM_STR);
 
             $reply_to_chat_id = null;

--- a/src/Entities/Chat.php
+++ b/src/Entities/Chat.php
@@ -15,18 +15,20 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#chat
  *
- * @property int    $id            Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
- * @property string $type          Type of chat, can be either "private", "group", "supergroup" or "channel"
- * @property string $title         Optional. Title, for channels and group chats
- * @property string $username      Optional. Username, for private chats, supergroups and channels if available
- * @property string $first_name    Optional. First name of the other party in a private chat
- * @property string $last_name     Optional. Last name of the other party in a private chat
- * @method   int    getId()        Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
- * @method   string getType()      Type of chat, can be either "private ", "group", "supergroup" or "channel"
- * @method   string getTitle()     Optional. Title, for channels and group chats
- * @method   string getUsername()  Optional. Username, for private chats, supergroups and channels if available
- * @method   string getFirstName() Optional. First name of the other party in a private chat
- * @method   string getLastName()  Optional. Last name of the other party in a private chat
+ * @property int    $id                              Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @property string $type                            Type of chat, can be either "private", "group", "supergroup" or "channel"
+ * @property string $title                           Optional. Title, for channels and group chats
+ * @property string $username                        Optional. Username, for private chats, supergroups and channels if available
+ * @property string $first_name                      Optional. First name of the other party in a private chat
+ * @property string $last_name                       Optional. Last name of the other party in a private chat
+ * @property bool   $all_members_are_administrators  Optional. True if a group has ‘All Members Are Admins’ enabled.
+ * @method   int    getId()                          Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @method   string getType()                        Type of chat, can be either "private ", "group", "supergroup" or "channel"
+ * @method   string getTitle()                       Optional. Title, for channels and group chats
+ * @method   string getUsername()                    Optional. Username, for private chats, supergroups and channels if available
+ * @method   string getFirstName()                   Optional. First name of the other party in a private chat
+ * @method   string getLastName()                    Optional. Last name of the other party in a private chat
+ * @method   bool   getAllMembersAreAdministrators() Optional. True if a group has ‘All Members Are Admins’ enabled.
  */
 class Chat extends Entity
 {

--- a/src/Entities/InlineQuery/InlineQueryResultAudio.php
+++ b/src/Entities/InlineQuery/InlineQueryResultAudio.php
@@ -23,6 +23,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  *   'id'                    => '',
  *   'audio_url'             => '',
  *   'title'                 => '',
+ *   'caption'               => '',
  *   'performer'             => '',
  *   'audio_duration'        => 123,
  *   'reply_markup'          => <InlineKeyboard>,
@@ -34,6 +35,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method string               getId()                  Unique identifier for this result, 1-64 bytes
  * @method string               getAudioUrl()            A valid URL for the audio file
  * @method string               getTitle()               Title
+ * @method string               getCaption()             Optional. Caption, 0-200 characters
  * @method string               getPerformer()           Optional. Performer
  * @method int                  getAudioDuration()       Optional. Audio duration in seconds
  * @method InlineKeyboard       getReplyMarkup()         Optional. Inline keyboard attached to the message
@@ -42,6 +44,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setId(string $id)                                                  Unique identifier for this result, 1-64 bytes
  * @method $this setAudioUrl(string $audio_url)                                     A valid URL for the audio file
  * @method $this setTitle(string $title)                                            Title
+ * @method $this setCaption(string $caption)                                        Optional. Caption, 0-200 characters
  * @method $this setPerformer(string $performer)                                    Optional. Performer
  * @method $this setAudioDuration(int $audio_duration)                              Optional. Audio duration in seconds
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message

--- a/src/Entities/InlineQuery/InlineQueryResultCachedAudio.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedAudio.php
@@ -22,6 +22,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * $data = [
  *   'id'                    => '',
  *   'audio_file_id'         => '',
+ *   'caption'               => '',
  *   'reply_markup'          => <InlineKeyboard>,
  *   'input_message_content' => <InputMessageContent>,
  * ];
@@ -30,11 +31,13 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method string               getType()                Type of the result, must be audio
  * @method string               getId()                  Unique identifier for this result, 1-64 bytes
  * @method string               getAudioFileId()         A valid file identifier for the audio file
+ * @method string               getCaption()             Optional. Caption, 0-200 characters
  * @method InlineKeyboard       getReplyMarkup()         Optional. An Inline keyboard attached to the message
  * @method InputMessageContent  getInputMessageContent() Optional. Content of the message to be sent instead of the audio
  *
  * @method $this setId(string $id)                                                  Unique identifier for this result, 1-64 bytes
  * @method $this setAudioFileId(string $audio_file_id)                              A valid file identifier for the audio file
+ * @method $this setCaption(string $caption)                                        Optional. Caption, 0-200 characters
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the audio
  */

--- a/src/Entities/InlineQuery/InlineQueryResultCachedVoice.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedVoice.php
@@ -23,6 +23,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  *   'id'                    => '',
  *   'voice_file_id'         => '',
  *   'title'                 => '',
+ *   'caption'               => '',
  *   'reply_markup'          => <InlineKeyboard>,
  *   'input_message_content' => <InputMessageContent>,
  * ];
@@ -32,12 +33,14 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method string               getId()                  Unique identifier for this result, 1-64 bytes
  * @method string               getVoiceFileId()         A valid file identifier for the voice message
  * @method string               getTitle()               Voice message title
+ * @method string               getCaption()             Optional. Caption, 0-200 characters
  * @method InlineKeyboard       getReplyMarkup()         Optional. An Inline keyboard attached to the message
  * @method InputMessageContent  getInputMessageContent() Optional. Content of the message to be sent instead of the voice message
  *
  * @method $this setId(string $id)                                                  Unique identifier for this result, 1-64 bytes
  * @method $this setVoiceFileId(string $voice_file_id)                              A valid file identifier for the voice message
  * @method $this setTitle(string $title)                                            Voice message title
+ * @method $this setCaption(string $caption)                                        Optional. Caption, 0-200 characters
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the voice message
  */

--- a/src/Entities/InlineQuery/InlineQueryResultVoice.php
+++ b/src/Entities/InlineQuery/InlineQueryResultVoice.php
@@ -23,6 +23,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  *   'id'                    => '',
  *   'voice_url'             => '',
  *   'title'                 => '',
+ *   'caption'               => '',
  *   'voice_duration'        => 123,
  *   'reply_markup'          => <InlineKeyboard>,
  *   'input_message_content' => <InputMessageContent>,
@@ -33,6 +34,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method string               getId()                  Unique identifier for this result, 1-64 bytes
  * @method string               getVoiceUrl()            A valid URL for the voice recording
  * @method string               getTitle()               Recording title
+ * @method string               getCaption()             Optional. Caption, 0-200 characters
  * @method int                  getVoiceDuration()       Optional. Recording duration in seconds
  * @method InlineKeyboard       getReplyMarkup()         Optional. Inline keyboard attached to the message
  * @method InputMessageContent  getInputMessageContent() Optional. Content of the message to be sent instead of the voice recording
@@ -40,6 +42,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setId(string $id)                                                  Unique identifier for this result, 1-64 bytes
  * @method $this setVoiceUrl(string $voice_url)                                     A valid URL for the voice recording
  * @method $this setTitle(string $title)                                            Recording title
+ * @method $this setCaption(string $caption)                                        Optional. Caption, 0-200 characters
  * @method $this setVoiceDuration(int $voice_duration)                              Optional. Recording duration in seconds
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the voice recording

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -21,6 +21,7 @@ namespace Longman\TelegramBot\Entities;
  * @method Chat     getChat()                  Conversation the message belongs to
  * @method User     getForwardFrom()           Optional. For forwarded messages, sender of the original message
  * @method Chat     getForwardFromChat()       Optional. For messages forwarded from a channel, information about the original channel
+ * @method int      getForwardFromMessageId()  Optional. For forwarded channel posts, identifier of the original message in the channel
  * @method int      getForwardDate()           Optional. For forwarded messages, date the original message was sent in Unix time
  * @method Message  getReplyToMessage()        Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
  * @method int      getEditDate()              Optional. Date the message was last edited in Unix time

--- a/structure.sql
+++ b/structure.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS `chat` (
   `id` bigint COMMENT 'Unique user or chat identifier',
   `type` ENUM('private', 'group', 'supergroup', 'channel') NOT NULL COMMENT 'Chat type, either private, group, supergroup or channel',
   `title` CHAR(255) DEFAULT '' COMMENT 'Chat (group) title, is null if chat type is private',
+  `all_members_are_administrators` tinyint(1) DEFAULT 0 COMMENT 'True if a all members of this group are admins',
   `created_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date creation',
   `updated_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date update',
   `old_id` bigint DEFAULT NULL COMMENT 'Unique chat identifier, this is filled when a group is converted to a supergroup',

--- a/structure.sql
+++ b/structure.sql
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS `message` (
   `date` timestamp NULL DEFAULT NULL COMMENT 'Date the message was sent in timestamp format',
   `forward_from` bigint NULL DEFAULT NULL COMMENT 'Unique user identifier, sender of the original message',
   `forward_from_chat` bigint NULL DEFAULT NULL COMMENT 'Unique chat identifier, chat the original message belongs to',
+  `forward_from_message_id` bigint NULL DEFAULT NULL COMMENT 'Unique chat identifier of the original message in the channel',
   `forward_date` timestamp NULL DEFAULT NULL COMMENT 'date the original message was sent in timestamp format',
   `reply_to_chat` bigint NULL DEFAULT NULL COMMENT 'Unique chat identifier',
   `reply_to_message` bigint UNSIGNED DEFAULT NULL COMMENT 'Message that this message is reply to',

--- a/tests/unit/TestHelpers.php
+++ b/tests/unit/TestHelpers.php
@@ -48,6 +48,7 @@ class TestHelpers
         'last_name' => 'last',
         'username' => 'name',
         'type' => 'private',
+        'all_members_are_administrators' => false,
     ];
 
     /**


### PR DESCRIPTION
Added a bunch of changes to reflect the changes of the Telegram API.

- Added the new field forward_from_message_id to Message.
- Added the new parameter cache_time to answerCallbackQuery.
- Added caption fields to sendAudio, sendVoice, InlineQueryResultAudio, InlineQueryResultVoice, InlineQueryResultCachedAudio, and InlineQueryResultCachedVoice.
- New field all_members_are_administrators in the Chat object.