### PR TITLE
Botan improvements and misc fixes

### DIFF
--- a/examples/Commands/EditmessageCommand.php
+++ b/examples/Commands/EditmessageCommand.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\UserCommands;
+
+use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Request;
+
+/**
+ * User "/editmessage" command
+ */
+class EditmessageCommand extends UserCommand
+{
+    /**#@+
+     * {@inheritdoc}
+     */
+    protected $name = 'editmessage';
+    protected $description = 'Edit message';
+    protected $usage = '/editmessage';
+    protected $version = '1.0.0';
+    /**#@-*/
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        $message = $this->getMessage();
+        $chat_id = $message->getChat()->getId();
+        $reply_to_message = $message->getReplyToMessage();
+		$text = $message->getText(true);
+
+        if ($reply_to_message) {
+            $message_to_edit = $reply_to_message->getMessageId();
+        }
+
+        if (isset($message_to_edit) && $message_to_edit) {
+            $data_edit = [];
+            $data_edit['chat_id'] = $chat_id;
+            $data_edit['message_id'] = $message_to_edit;
+
+			if (!empty($text)) {
+                $data_edit['text'] = $text;
+			} else {
+                $data_edit['text'] = "Edited message";
+			}
+
+            return Request::editMessageText($data_edit);
+        } else {
+            $data = [];
+            $data['chat_id'] = $chat_id;
+            $data['text'] = 'Reply to any bot\'s message and use /' . $this->name . ' <your text> to edit it.';
+            return Request::sendMessage($data);
+        }
+    }
+}

--- a/examples/Commands/ShortenerCommand.php
+++ b/examples/Commands/ShortenerCommand.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\UserCommands;
+
+use Longman\TelegramBot\Botan;
+use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Request;
+
+/**
+ * User "/shortener" command
+ */
+class ShortenerCommand extends UserCommand
+{
+    /**#@+
+     * {@inheritdoc}
+     */
+    protected $name = 'shortener';
+    protected $description = 'Botan Shortener example';
+    protected $usage = '/shortener';
+    protected $version = '1.0.0';
+    /**#@-*/
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        $message = $this->getMessage();
+        $chat_id = $message->getChat()->getId();
+        $user_id = $message->getFrom()->getId();
+
+        $data = [];
+        $data['chat_id'] = $chat_id;
+
+        $text = Botan::shortenUrl("https://github.com/akalongman/php-telegram-bot", $user_id);
+
+        $data['text'] = $text;
+
+        return Request::sendMessage($data);
+    }
+}

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -62,7 +62,9 @@ try {
     //$telegram->setUploadPath('../Upload');
 
     // Botan.io integration
+    // Second argument is optional maximum timeout
     //$telegram->enableBotan('your_token');
+    //$telegram->enableBotan('your_token', 3);
 
     // Handle telegram getUpdates request
     $serverResponse = $telegram->handleGetUpdates();

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -64,7 +64,7 @@ try {
     // Botan.io integration
     // Second argument is optional maximum timeout
     //$telegram->enableBotan('your_token');
-    //$telegram->enableBotan('your_token', 3);
+    //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Handle telegram getUpdates request
     $serverResponse = $telegram->handleGetUpdates();

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -62,7 +62,7 @@ try {
     //$telegram->setUploadPath('../Upload');
 
     // Botan.io integration
-    // Second argument is optional maximum timeout
+    // Second argument are options
     //$telegram->enableBotan('your_token');
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -61,7 +61,9 @@ try {
     //$telegram->setUploadPath('../Upload');
 
     // Botan.io integration
+    // Second argument is optional maximum timeout
     //$telegram->enableBotan('your_token');
+    //$telegram->enableBotan('your_token', 3);
 
     // Handle telegram webhook request
     $telegram->handle();

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -61,7 +61,7 @@ try {
     //$telegram->setUploadPath('../Upload');
 
     // Botan.io integration
-    // Second argument is optional maximum timeout
+    // Second argument are options
     //$telegram->enableBotan('your_token');
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -63,7 +63,7 @@ try {
     // Botan.io integration
     // Second argument is optional maximum timeout
     //$telegram->enableBotan('your_token');
-    //$telegram->enableBotan('your_token', 3);
+    //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Handle telegram webhook request
     $telegram->handle();

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -194,7 +194,12 @@ class Botan
             $responseData = json_decode($response, true);
 
             if ($responseData['status'] !== 'accepted') {
-                TelegramLog::debug("Botan.io API replied with error:\n$response\n\n");
+                if (!empty($response)) {
+                    TelegramLog::debug("Botan.io track post failed, API reply:\n$response\n\n");
+                } else {
+                    TelegramLog::debug("Botan.io track post failed, API returned empty response!\n\n");
+                }
+
                 return false;
             }
 
@@ -245,7 +250,12 @@ class Botan
                 BotanDB::insertShortUrl($user_id, $url, $response);
                 return $response;
             } else {
-                TelegramLog::error("Botan.io URL shortening failed - API replied with error:\n$response\n\n");
+                if (!empty($response)) {
+                    TelegramLog::debug("Botan.io URL shortening failed for '$url', API reply:\n$response\n\n");
+                } else {
+                    TelegramLog::debug("Botan.io URL shortening failed for '$url', API returned empty response!\n\n");
+                }
+
                 return $url;
             }
         }

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -194,11 +194,7 @@ class Botan
             $responseData = json_decode($result, true);
 
             if ($responseData['status'] !== 'accepted') {
-                if (!empty($result)) {
-                    TelegramLog::debug("Botan.io stats report failed: $result\n\n");
-                } else {
-                    TelegramLog::debug("Botan.io stats report failed: empty response!\n\n");
-                }
+                TelegramLog::debug('Botan.io stats report failed: ' . ($result ?: 'empty response') . "\n\n");
 
                 return false;
             }
@@ -247,11 +243,7 @@ class Botan
                 BotanDB::insertShortUrl($user_id, $url, $result);
                 return $result;
             } else {
-                if (!empty($result)) {
-                    TelegramLog::debug("Botan.io URL shortening failed for '$url': $result\n\n");
-                } else {
-                    TelegramLog::debug("Botan.io URL shortening failed for '$url': empty response!\n\n");
-                }
+                TelegramLog::debug('Botan.io URL shortening failed for \'' . $url . '\': ' . ($result ?: 'empty response') . "\n\n");
 
                 return $url;
             }

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -166,11 +166,7 @@ class Botan
         }
 
         // In case there is no from field assign id = 0
-        if (isset($data['from']['id'])) {
-            $uid = $data['from']['id'];
-        } else {
-            $uid = 0;
-        }
+        $uid = (isset($data['from']['id'])) ? $data['from']['id'] : 0;
 
         try {
             $response = self::$client->post(
@@ -222,7 +218,7 @@ class Botan
             throw new TelegramException('User id is empty!');
         }
 
-        if ($cached = BotanDB::selectShortUrl($user_id, $url)) {
+        if ($cached = BotanDB::selectShortUrl($url, $user_id)) {
             return $cached;
         }
 
@@ -240,7 +236,7 @@ class Botan
             $result = $e->getMessage();
         } finally {
             if (filter_var($result, FILTER_VALIDATE_URL) !== false) {
-                BotanDB::insertShortUrl($user_id, $url, $result);
+                BotanDB::insertShortUrl($url, $user_id, $result);
                 return $result;
             } else {
                 TelegramLog::debug('Botan.io URL shortening failed for \'' . $url . '\': ' . ($result ?: 'empty response') . "\n\n");

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -120,7 +120,7 @@ class Botan
         $data = [];
         if ($update->getMessage()) {
             $data       = $update_data['message'];
-            $event_name = 'Generic Message';
+            $event_name = 'Message';
 
             if (!empty($data['entities']) && is_array($data['entities'])) {
                 foreach ($data['entities'] as $entity) {

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -187,17 +187,17 @@ class Botan
                 ]
             );
 
-            $response = (string) $response->getBody();
+            $result = (string) $response->getBody();
         } catch (RequestException $e) {
-            $response = ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
+            $result = $e->getMessage();
         } finally {
-            $responseData = json_decode($response, true);
+            $responseData = json_decode($result, true);
 
             if ($responseData['status'] !== 'accepted') {
-                if (!empty($response)) {
-                    TelegramLog::debug("Botan.io stats report failed, API reply: $response");
+                if (!empty($result)) {
+                    TelegramLog::debug("Botan.io stats report failed: $result\n\n");
                 } else {
-                    TelegramLog::debug("Botan.io stats report failed, API returned empty response!");
+                    TelegramLog::debug("Botan.io stats report failed: empty response!\n\n");
                 }
 
                 return false;
@@ -239,18 +239,18 @@ class Botan
                 )
             );
 
-            $response = (string) $response->getBody();
+            $result = (string) $response->getBody();
         } catch (RequestException $e) {
-            $response = ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
+            $result = $e->getMessage();
         } finally {
-            if (filter_var($response, FILTER_VALIDATE_URL) !== false) {
-                BotanDB::insertShortUrl($user_id, $url, $response);
-                return $response;
+            if (filter_var($result, FILTER_VALIDATE_URL) !== false) {
+                BotanDB::insertShortUrl($user_id, $url, $result);
+                return $result;
             } else {
-                if (!empty($response)) {
-                    TelegramLog::debug("Botan.io URL shortening failed for '$url', API reply: $response");
+                if (!empty($result)) {
+                    TelegramLog::debug("Botan.io URL shortening failed for '$url': $result\n\n");
                 } else {
-                    TelegramLog::debug("Botan.io URL shortening failed for '$url', API returned empty response!");
+                    TelegramLog::debug("Botan.io URL shortening failed for '$url': empty response!\n\n");
                 }
 
                 return $url;

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -10,6 +10,9 @@
 
 namespace Longman\TelegramBot;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Exception\TelegramException;
 
 /**
@@ -20,82 +23,107 @@ use Longman\TelegramBot\Exception\TelegramException;
 class Botan
 {
     /**
-     * @var string Tracker request url
+     * Botan.io API URL
+     *
+     * @var string
      */
-    protected static $track_url = 'https://api.botan.io/track?token=#TOKEN&uid=#UID&name=#NAME';
+    protected static $api_base_uri = 'https://api.botan.io';
 
     /**
-     * @var string Url Shortener request url
-     */
-    protected static $shortener_url = 'https://api.botan.io/s/?token=#TOKEN&user_ids=#UID&url=#URL';
-
-    /**
-     * @var string Yandex AppMetrica application key
+     * Yandex AppMetrica application key
+     *
+     * @var string
      */
     protected static $token = '';
 
     /**
-     * @var string The actual command that is going to be reported
+     * Guzzle Client object
+     *
+     * @var \GuzzleHttp\Client
+     */
+    private static $client;
+
+    /**
+     * The actual command that is going to be reported
+     *
+     *  Set as public to let the developers either:
+     *  - block tracking from inside commands by setting the value to non-existent command
+     *  - override which command is tracked when commands call other commands with executedCommand()
+     *
+     * @var string
      */
     public static $command = '';
 
     /**
      * Initialize Botan
      *
-     * @param $token
+     * @param  string $token
+     * @param  integer $timeout
+     *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public static function initializeBotan($token)
+    public static function initializeBotan($token, $timeout = 3)
     {
-        if (empty($token) || !is_string($token)) {
-            throw new TelegramException('Botan token should be a string!');
+        if (empty($token)) {
+            throw new TelegramException('Botan token is empty!');
         }
-        self::$token = $token;
+
+        if (!is_numeric($timeout)) {
+            throw new TelegramException('Timeout must be a number!');
+        }
+
+        self::$token   = $token;
+        self::$client  = new Client(['base_uri' => self::$api_base_uri, 'timeout' => $timeout]);
+
         BotanDB::initializeBotanDb();
     }
 
     /**
-     * Lock function to make sure only the first command is reported
-     * ( in case commands are calling other commands $telegram->executedCommand() )
+     * Lock function to make sure only the first command is reported (the one user requested)
      *
-     * @param  string $command
+     *  This is in case commands are calling other commands with executedCommand()
+     *
+     * @param string $command
      */
     public static function lock($command = '')
     {
         if (empty(self::$command)) {
-            self::$command = $command;
+            self::$command = strtolower($command);
         }
     }
 
     /**
      * Track function
      *
-     * @param  string $input
+     * @param  \Longman\TelegramBot\Entities\Update $update
      * @param  string $command
      *
      * @return bool|string
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public static function track($input, $command = '')
+    public static function track(Update $update, $command = '')
     {
-        if (empty(self::$token) || $command !== self::$command) {
+        if (empty(self::$token) || strtolower($command) !== self::$command) {
             return false;
         }
 
-        if (empty($input)) {
-            throw new TelegramException('Input is empty!');
+        if (empty($update)) {
+            throw new TelegramException('Update object is empty!');
         }
 
+        // Release the lock in case someone runs getUpdates in foreach loop
         self::$command = '';
 
-        $obj  = json_decode($input, true);
-        $data = [];
-        if (isset($obj['message'])) {
-            $data       = $obj['message'];
-            $event_name = 'Message';
+        // For now, this is the only way
+        $update_data = (array) $update;
 
-            if (isset($obj['message']['entities']) && is_array($obj['message']['entities'])) {
-                foreach ($obj['message']['entities'] as $entity) {
+        $data = [];
+        if ($update->getMessage()) {
+            $data       = $update_data['message'];
+            $event_name = 'Generic Message';
+
+            if (!empty($data['entities']) && is_array($data['entities'])) {
+                foreach ($data['entities'] as $entity) {
                     if ($entity['type'] === 'bot_command' && $entity['offset'] === 0) {
                         if (strtolower($command) === 'generic') {
                             $command = 'Generic';
@@ -110,23 +138,23 @@ class Botan
                     }
                 }
             }
-        } elseif (isset($obj['edited_message'])) {
-            $data       = $obj['edited_message'];
+        } elseif ($update->getEditedMessage()) {
+            $data       = $update_data['edited_message'];
             $event_name = 'Edited Message';
-        } elseif (isset($obj['channel_post'])) {
-            $data       = $obj['channel_post'];
-            $event_name = 'Channel Message';
-        } elseif (isset($obj['edited_channel_post'])) {
-            $data       = $obj['edited_channel_post'];
-            $event_name = 'Edited Channel Message';
-        } elseif (isset($obj['inline_query'])) {
-            $data       = $obj['inline_query'];
+        } elseif ($update->getChannelPost()) {
+            $data       = $update_data['channel_post'];
+            $event_name = 'Channel Post';
+        } elseif ($update->getEditedChannelPost()) {
+            $data       = $update_data['edited_channel_post'];
+            $event_name = 'Edited Channel Post';
+        } elseif ($update->getInlineQuery()) {
+            $data       = $update_data['inline_query'];
             $event_name = 'Inline Query';
-        } elseif (isset($obj['chosen_inline_result'])) {
-            $data       = $obj['chosen_inline_result'];
+        } elseif ($update->getChosenInlineResult()) {
+            $data       = $update_data['chosen_inline_result'];
             $event_name = 'Chosen Inline Result';
-        } elseif (isset($obj['callback_query'])) {
-            $data       = $obj['callback_query'];
+        } elseif ($update->getCallbackQuery()) {
+            $data       = $update_data['callback_query'];
             $event_name = 'Callback Query';
         }
 
@@ -134,38 +162,51 @@ class Botan
             return false;
         }
 
-        $uid     = $data['from']['id'];
-        $request = str_replace(
-            ['#TOKEN', '#UID', '#NAME'],
-            [self::$token, $uid, urlencode($event_name)],
-            self::$track_url
-        );
-
-        $options = [
-            'http' => [
-                'header'        => 'Content-Type: application/json',
-                'method'        => 'POST',
-                'content'       => json_encode($data),
-                'ignore_errors' => true,
-            ],
-        ];
-
-        $context      = stream_context_create($options);
-        $response     = @file_get_contents($request, false, $context);
-        $responseData = json_decode($response, true);
-
-        if ($responseData['status'] !== 'accepted') {
-            TelegramLog::debug('Botan.io API replied with error: ' . $response);
+        // In case there is no from field (channel posts) assign chat id
+        if (isset($data['from']['id'])) {
+            $uid = $data['from']['id'];
+        } elseif (isset($data['chat']['id'])) {
+            $uid = $data['chat']['id'];
+        } else {
+            $uid = 0;   // if that fails too assign id = 0
         }
 
-        return $responseData;
+        try {
+            $response = self::$client->request(
+                'POST',
+                str_replace(
+                    ['#TOKEN', '#UID', '#NAME'],
+                    [self::$token, $uid, urlencode($event_name)],
+                    '/track?token=#TOKEN&uid=#UID&name=#NAME'
+                ),
+                [
+                    'headers' => [
+                        'Content-Type' => 'application/json'
+                    ],
+                    'json' => $data
+                ]
+            );
+
+            $response = (string) $response->getBody();
+        } catch (RequestException $e) {
+            $response = ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
+        } finally {
+            $responseData = json_decode($response, true);
+
+            if ($responseData['status'] !== 'accepted') {
+                TelegramLog::debug("Botan.io API replied with error:\n$response\n\n");
+                return false;
+            }
+
+            return $responseData;
+        }
     }
 
     /**
      * Url Shortener function
      *
-     * @param  $url
-     * @param  $user_id
+     * @param  string $url
+     * @param  integer $user_id
      *
      * @return string
      * @throws \Longman\TelegramBot\Exception\TelegramException
@@ -181,33 +222,32 @@ class Botan
         }
 
         $cached = BotanDB::selectShortUrl($user_id, $url);
-        if (!empty($cached[0]['short_url'])) {
-            return $cached[0]['short_url'];
+
+        if (!empty($cached)) {
+            return $cached;
         }
 
-        $request = str_replace(
-            ['#TOKEN', '#UID', '#URL'],
-            [self::$token, $user_id, urlencode($url)],
-            self::$shortener_url
-        );
+        try {
+            $response = self::$client->request(
+                'POST',
+                str_replace(
+                    ['#TOKEN', '#UID', '#URL'],
+                    [self::$token, $user_id, urlencode($url)],
+                    '/s/?token=#TOKEN&user_ids=#UID&url=#URL'
+                )
+            );
 
-        $options = [
-            'http' => [
-                'ignore_errors' => true,
-                'timeout'       => 3,
-            ],
-        ];
-
-        $context  = stream_context_create($options);
-        $response = @file_get_contents($request, false, $context);
-
-        if (!filter_var($response, FILTER_VALIDATE_URL) === false) {
-            BotanDB::insertShortUrl($user_id, $url, $response);
-        } else {
-            TelegramLog::debug('Botan.io API replied with error: ' . $response);
-            return $url;
+            $response = (string) $response->getBody();
+        } catch (RequestException $e) {
+            $response = ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
+        } finally {
+            if (!filter_var($response, FILTER_VALIDATE_URL) === false) {
+                BotanDB::insertShortUrl($user_id, $url, $response);
+                return $response;
+            } else {
+                TelegramLog::error("Botan.io URL shortening failed - API replied with error:\n$response\n\n");
+                return $url;
+            }
         }
-
-        return $response;
     }
 }

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -136,7 +136,7 @@ class Botan
             'callback_query' => 'Callback Query'
         ];
 
-        if (in_array($update_type, ['message', 'edited_message', 'channel_post', 'edited_channel_post', 'inline_query', 'chosen_inline_result', 'callback_query'], true)) {
+        if (array_key_exists($update_type, $update_object_names)) {
             $data       = $update_data[$update_type];
             $event_name = $update_object_names[$update_type];
 

--- a/src/BotanDB.php
+++ b/src/BotanDB.php
@@ -32,13 +32,13 @@ class BotanDB extends DB
     /**
      * Select cached shortened URL from the database
      *
-     * @param $user_id
-     * @param $url
+     * @param string  $url
+     * @param integer $user_id
      *
      * @return array|bool
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public static function selectShortUrl($user_id, $url)
+    public static function selectShortUrl($url, $user_id)
     {
         if (!self::isDbConnected()) {
             return false;
@@ -65,14 +65,14 @@ class BotanDB extends DB
     /**
      * Insert shortened URL into the database
      *
-     * @param $user_id
-     * @param $url
-     * @param $short_url
+     * @param string  $url
+     * @param integer $user_id
+     * @param string  $short_url
      *
      * @return bool
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public static function insertShortUrl($user_id, $url, $short_url)
+    public static function insertShortUrl($url, $user_id, $short_url)
     {
         if (!self::isDbConnected()) {
             return false;

--- a/src/BotanDB.php
+++ b/src/BotanDB.php
@@ -47,13 +47,21 @@ class BotanDB extends DB
         try {
             $sth = self::$pdo->prepare('SELECT * FROM `' . TB_BOTAN_SHORTENER . '`
                 WHERE `user_id` = :user_id AND `url` = :url
+                ORDER BY `created_at` DESC
+                LIMIT 1
             ');
 
             $sth->bindParam(':user_id', $user_id, PDO::PARAM_INT);
-            $sth->bindParam(':url', $url, PDO::PARAM_INT);
+            $sth->bindParam(':url', $url, PDO::PARAM_STR);
             $sth->execute();
 
-            return $sth->fetchAll(PDO::FETCH_ASSOC);
+            $result = $sth->fetchAll(PDO::FETCH_ASSOC);
+
+            if (isset($result[0]['short_url'])) {
+                return $result[0]['short_url'];
+            }
+
+            return $result;
         } catch (Exception $e) {
             throw new TelegramException($e->getMessage());
         }

--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -81,7 +81,7 @@ class SendtochannelCommand extends AdminCommand
         $notes = &$this->conversation->notes;
         !is_array($notes) && $notes = [];
 
-        $channels = (array)$this->getConfig('your_channel');
+        $channels = (array) $this->getConfig('your_channel');
         if (isset($notes['state'])) {
             $state = $notes['state'];
         } else {
@@ -347,7 +347,7 @@ class SendtochannelCommand extends AdminCommand
         ];
 
         if ($text !== '') {
-            $channels      = (array)$this->getConfig('your_channel');
+            $channels      = (array) $this->getConfig('your_channel');
             $first_channel = $channels[0];
             $data['text']  = $this->publish(
                 new Message($message->getRawData(), $this->telegram->getBotName()),

--- a/src/Commands/UserCommands/WeatherCommand.php
+++ b/src/Commands/UserCommands/WeatherCommand.php
@@ -74,7 +74,7 @@ class WeatherCommand extends UserCommand
             return '';
         }
 
-        return (string)$response->getBody();
+        return (string) $response->getBody();
     }
 
     /**

--- a/src/DB.php
+++ b/src/DB.php
@@ -483,7 +483,7 @@ class DB
                     $edited_message_local_id
                 );
             }
-        } else if ($update_type === 'channel_post') {
+        } elseif ($update_type === 'channel_post') {
             $channel_post = $update->getChannelPost();
 
             if (self::insertMessageRequest($channel_post)) {

--- a/src/Entities/Keyboard.php
+++ b/src/Entities/Keyboard.php
@@ -90,7 +90,7 @@ class Keyboard extends Entity
 
         $data = reset($args);
 
-        if ($from_data = array_key_exists($keyboard_type, (array)$data)) {
+        if ($from_data = array_key_exists($keyboard_type, (array) $data)) {
             $args = $data[$keyboard_type];
 
             // Make sure we're working with a proper row.

--- a/src/Entities/ServerResponse.php
+++ b/src/Entities/ServerResponse.php
@@ -36,7 +36,7 @@ class ServerResponse extends Entity
         unset($data['raw_data']);
         $data['raw_data'] = $data;
 
-        $is_ok  = isset($data['ok']) ? (bool)$data['ok'] : false;
+        $is_ok  = isset($data['ok']) ? (bool) $data['ok'] : false;
         $result = isset($data['result']) ? $data['result'] : null;
 
         if ($is_ok && is_array($result)) {
@@ -71,7 +71,7 @@ class ServerResponse extends Entity
      */
     public function isOk()
     {
-        return (bool)$this->getOk();
+        return (bool) $this->getOk();
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -219,7 +219,7 @@ class Request
                 '/bot' . self::$telegram->getApiKey() . '/' . $action,
                 $request_params
             );
-            $result   = (string)$response->getBody();
+            $result   = (string) $response->getBody();
 
             //Logging getUpdates Update
             if ($action === 'getUpdates') {

--- a/src/Request.php
+++ b/src/Request.php
@@ -226,7 +226,7 @@ class Request
                 TelegramLog::update($result);
             }
         } catch (RequestException $e) {
-            $result = (string)$e->getResponse()->getBody();
+            $result = ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
         } finally {
             //Logging verbose debug output
             TelegramLog::endDebugLogTempStream("Verbose HTTP Request output:\n%s\n");
@@ -265,7 +265,7 @@ class Request
 
             return filesize($file_path) > 0;
         } catch (RequestException $e) {
-            return (string)$e->getResponse()->getBody();
+            return ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
         } finally {
             //Logging verbose debug output
             TelegramLog::endDebugLogTempStream("Verbose HTTP File Download Request output:\n%s\n");

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -455,7 +455,7 @@ class Telegram
             //Handle a generic command or non existing one
             $this->last_command_response = $this->executeCommand('Generic');
         } else {
-            //Botan.io integration, make sure only the command user executed is reported
+            //Botan.io integration, make sure only the actual command user executed is reported
             if ($this->botan_enabled) {
                 Botan::lock($command);
             }
@@ -815,14 +815,15 @@ class Telegram
     /**
      * Enable Botan.io integration
      *
-     * @param  $token
+     * @param  string $token
+     * @param  integer $timeout
      *
      * @return \Longman\TelegramBot\Telegram
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function enableBotan($token)
+    public function enableBotan($token, $timeout = 3)
     {
-        Botan::initializeBotan($token);
+        Botan::initializeBotan($token, $timeout);
         $this->botan_enabled = true;
 
         return $this;

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -817,14 +817,14 @@ class Telegram
      * Enable Botan.io integration
      *
      * @param  string $token
-     * @param  integer $timeout
+     * @param  array $options
      *
      * @return \Longman\TelegramBot\Telegram
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function enableBotan($token, $timeout = 3)
+    public function enableBotan($token, array $options = [])
     {
-        Botan::initializeBotan($token, $timeout);
+        Botan::initializeBotan($token, $options);
         $this->botan_enabled = true;
 
         return $this;

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -331,7 +331,7 @@ class Telegram
         if ($response->isOk()) {
             //Process all updates
             /** @var Update $result */
-            foreach ((array)$response->getResult() as $result) {
+            foreach ((array) $response->getResult() as $result) {
                 $this->processUpdate($result);
             }
         }
@@ -420,7 +420,8 @@ class Telegram
                 'new_chat_photo',
                 'new_chat_title',
                 'supergroup_chat_created',
-            ], true)) {
+            ], true)
+            ) {
                 $command = $this->getCommandFromType($type);
             }
         }


### PR DESCRIPTION
Botan.io:
- moved to Guzzle
- user can set own timeout for Botan requests `$telegram->enableBotan('TOKEN', ['timeout' => 5])`, defaults to 3
- added shortener usage example
- stated potential usage for `public static $command` in docblock
- fixed botan not working with getUpdates

Other:
- Fixed `Call to a member function getBody() on null` happening on empty or no replies (currently visible on Windows, will be replaced with 'invalid response' exception which is better)
- Fixed code with PHP Code Beautifier and Fixer
- Added example usage of editMessageText 
(I think it would be a good idea to make more usage/command examples based on past closed issues)