### PR TITLE
Fix Telegram request parameters

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -178,12 +178,16 @@ class Request
     private static function setUpRequestParams(array $data)
     {
         $has_resource = false;
-        $multipart    = [];
+        $multipart = [];
+
+        // Convert any nested arrays into JSON strings.
+        array_walk($data, function (&$item) {
+            is_array($item) && $item = json_encode($item);
+        });
 
         //Reformat data array in multipart way if it contains a resource
         foreach ($data as $key => $item) {
             $has_resource |= is_resource($item);
-            is_array($item) && $item = json_encode($item);
             $multipart[] = ['name' => $key, 'contents' => $item];
         }
         if ($has_resource) {


### PR DESCRIPTION
Due to the way that Telegram interprets the request URL, http_build_query that Guzzle uses doesn't work properly. Instead, we now convert all arrays to JSON encoded strings, which get interpreted correctly!

@jacklul Would appreciate you testing this to make sure it still works properly for you with self-signed certs.