### PR TITLE
Make access to the database easier

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -159,6 +159,16 @@ class DB
     }
 
     /**
+     * Get the PDO object of the connected database
+     *
+     * @return \PDO
+     */
+    public static function getPdo()
+    {
+        return self::$pdo;
+    }
+
+    /**
      * Fetch update(s) from DB
      *
      * @param int $limit Limit the number of updates to fetch


### PR DESCRIPTION
Add a new method to the DB class that returns the PDO object for direct querying.

Fix #373 