### PR TITLE
Add 'username' field to 'chat' table

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -408,18 +408,20 @@ class DB
 
         $chat_id                             = $chat->getId();
         $chat_title                          = $chat->getTitle();
+        $chat_username                       = $chat->getUsername();
         $chat_type                           = $chat->getType();
         $chat_all_members_are_administrators = $chat->getAllMembersAreAdministrators();
 
         try {
             $sth = self::$pdo->prepare('
                 INSERT IGNORE INTO `' . TB_CHAT . '`
-                (`id`, `type`, `title`, `all_members_are_administrators`, `created_at` ,`updated_at`, `old_id`)
+                (`id`, `type`, `title`, `username`, `all_members_are_administrators`, `created_at` ,`updated_at`, `old_id`)
                 VALUES
-                (:id, :type, :title, :all_members_are_administrators, :date, :date, :oldid)
+                (:id, :type, :title, :username, :all_members_are_administrators, :date, :date, :oldid)
                 ON DUPLICATE KEY UPDATE
                     `type`                           = :type,
                     `title`                          = :title,
+                    `username`                       = :username,
                     `all_members_are_administrators` = :all_members_are_administrators,
                     `updated_at`                     = :date
             ');
@@ -436,6 +438,7 @@ class DB
 
             $sth->bindParam(':type', $chat_type, PDO::PARAM_INT);
             $sth->bindParam(':title', $chat_title, PDO::PARAM_STR, 255);
+            $sth->bindParam(':username', $chat_username, PDO::PARAM_STR, 255);
             $sth->bindParam(':all_members_are_administrators', $chat_all_members_are_administrators, PDO::PARAM_INT);
             $sth->bindParam(':date', $date, PDO::PARAM_STR);
 

--- a/structure.sql
+++ b/structure.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS `chat` (
   `id` bigint COMMENT 'Unique user or chat identifier',
   `type` ENUM('private', 'group', 'supergroup', 'channel') NOT NULL COMMENT 'Chat type, either private, group, supergroup or channel',
   `title` CHAR(255) DEFAULT '' COMMENT 'Chat (group) title, is null if chat type is private',
+  `username` CHAR(255) DEFAULT NULL COMMENT 'Username, for private chats, supergroups and channels if available',
   `all_members_are_administrators` tinyint(1) DEFAULT 0 COMMENT 'True if a all members of this group are admins',
   `created_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date creation',
   `updated_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date update',


### PR DESCRIPTION
This was missing too!
Now bot can track channel and group public usernames!