### PR TITLE
Request limiter - prevent hitting Telegram's API limits

### DIFF
--- a/examples/cron.php
+++ b/examples/cron.php
@@ -60,6 +60,9 @@ try {
     //$telegram->setDownloadPath('../Download');
     //$telegram->setUploadPath('../Upload');
 
+    // Requests Limiter (tries to prevent reaching Telegram API limits)
+    $telegram->enableLimiter();
+
     // Run user selected commands
     $telegram->runCommands($commands);
 } catch (Longman\TelegramBot\Exception\TelegramException $e) {

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -67,7 +67,7 @@ try {
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
-    //$telegram->enableLimiter();
+    $telegram->enableLimiter();
 
     // Handle telegram getUpdates request
     $serverResponse = $telegram->handleGetUpdates();

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -66,6 +66,9 @@ try {
     //$telegram->enableBotan('your_token');
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
+    // Requests Limiter (tries to prevent reaching Telegram API limits)
+    //$telegram->enableLimiter();
+
     // Handle telegram getUpdates request
     $serverResponse = $telegram->handleGetUpdates();
 

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -66,7 +66,7 @@ try {
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
-    //$telegram->enableLimiter();
+    $telegram->enableLimiter();
 
     // Handle telegram webhook request
     $telegram->handle();

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -65,6 +65,9 @@ try {
     //$telegram->enableBotan('your_token');
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
+    // Requests Limiter (tries to prevent reaching Telegram API limits)
+    //$telegram->enableLimiter();
+
     // Handle telegram webhook request
     $telegram->handle();
 } catch (Longman\TelegramBot\Exception\TelegramException $e) {

--- a/src/DB.php
+++ b/src/DB.php
@@ -1079,7 +1079,7 @@ class DB
             $date = self::getTimestamp(time());
             $date_minute = self::getTimestamp(strtotime('-1 minute'));
 
-            $sth->bindParam(':chat_id', $chat_id, \PDO::PARAM_INT);
+            $sth->bindParam(':chat_id', $chat_id, \PDO::PARAM_STR);
             $sth->bindParam(':inline_message_id', $inline_message_id, \PDO::PARAM_STR);
             $sth->bindParam(':date', $date, \PDO::PARAM_STR);
             $sth->bindParam(':date_minute', $date_minute, \PDO::PARAM_STR);
@@ -1095,8 +1095,8 @@ class DB
     /**
      * Insert Telegram API request in db
      *
-     * @param string  $method
-     * @param array   $data
+     * @param string $method
+     * @param array  $data
      *
      * @return bool If the insert was successful
      * @throws \Longman\TelegramBot\Exception\TelegramException
@@ -1107,7 +1107,7 @@ class DB
             return false;
         }
 
-        $chat_id = ((isset($data['chat_id']) && $data['chat_id'] != 0) ? $data['chat_id'] : null);
+        $chat_id = ((isset($data['chat_id'])) ? $data['chat_id'] : null);
         $inline_message_id = (isset($data['inline_message_id']) ? $data['inline_message_id'] : null);
 
         try {
@@ -1122,7 +1122,7 @@ class DB
 
             $created_at = self::getTimestamp();
 
-            $sth->bindParam(':chat_id', $chat_id, \PDO::PARAM_INT);
+            $sth->bindParam(':chat_id', $chat_id, \PDO::PARAM_STR);
             $sth->bindParam(':inline_message_id', $inline_message_id, \PDO::PARAM_STR);
             $sth->bindParam(':method', $method, \PDO::PARAM_STR);
             $sth->bindParam(':date', $created_at, \PDO::PARAM_STR);

--- a/src/DB.php
+++ b/src/DB.php
@@ -1071,15 +1071,18 @@ class DB
 
         try {
             $sth = self::$pdo->prepare('SELECT 
-                (SELECT COUNT(*) FROM `' . TB_REQUEST_LIMITER . '` WHERE ((`chat_id` = :chat_id AND `inline_message_id` IS NULL) OR (`inline_message_id` = :inline_message_id AND `chat_id` IS NULL)) AND `created_at` >= :date) as CURRENT,
-                (SELECT COUNT(*) FROM `' . TB_REQUEST_LIMITER . '` WHERE `created_at` >= :date) as TOTAL
+                (SELECT COUNT(*) FROM `' . TB_REQUEST_LIMITER . '` WHERE `created_at` >= :date) as LIMIT_PER_SEC_ALL,
+                (SELECT COUNT(*) FROM `' . TB_REQUEST_LIMITER . '` WHERE ((`chat_id` = :chat_id AND `inline_message_id` IS NULL) OR (`inline_message_id` = :inline_message_id AND `chat_id` IS NULL)) AND `created_at` >= :date) as LIMIT_PER_SEC,
+                (SELECT COUNT(*) FROM `' . TB_REQUEST_LIMITER . '` WHERE `chat_id` = :chat_id AND `created_at` >= :date_minute) as LIMIT_PER_MINUTE
             ');
 
-            $date = self::getTimestamp();
+            $date = self::getTimestamp(time());
+            $date_minute = self::getTimestamp(strtotime('-1 minute'));
 
             $sth->bindParam(':chat_id', $chat_id, \PDO::PARAM_INT);
             $sth->bindParam(':inline_message_id', $inline_message_id, \PDO::PARAM_STR);
             $sth->bindParam(':date', $date, \PDO::PARAM_STR);
+            $sth->bindParam(':date_minute', $date_minute, \PDO::PARAM_STR);
 
             $sth->execute();
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -1042,12 +1042,9 @@ class Request
 
                     $requests = DB::getTelegramRequestCount($chat_id, $inline_message_id);
 
-                    if (
-                        $requests['LIMIT_PER_SEC'] == 0 &&  // No more than one message per second inside a particular chat
-                        (
-                            (($chat_id > 0 || $inline_message_id) && $requests['LIMIT_PER_SEC_ALL'] < 30) ||  // No more than 30 messages per second globally
-                            ($chat_id < 0 && $requests['LIMIT_PER_MINUTE'] < 20)  // No more than 20 messages per minute for group chats
-                        )
+                    if ($requests['LIMIT_PER_SEC'] == 0  // No more than one message per second inside a particular chat
+                        && ((($chat_id > 0 || $inline_message_id) && $requests['LIMIT_PER_SEC_ALL'] < 30)  // No more than 30 messages per second globally
+                        || ($chat_id < 0 && $requests['LIMIT_PER_MINUTE'] < 20))
                     ) {
                         break;
                     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -1028,6 +1028,10 @@ class Request
             if ((isset($data['chat_id']) || isset($data['inline_message_id'])) && in_array($action, $limited_methods)) {
                 $timeout = 60;
 
+                if (!is_numeric($data['chat_id'])) {
+                    $data['chat_id'] = 0;
+                }
+
                 while (true) {
                     $requests = DB::getTelegramRequestCount((isset($data['chat_id']) ? $data['chat_id'] : null), (isset($data['inline_message_id']) ? $data['inline_message_id'] : null));
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -829,4 +829,14 @@ class Telegram
 
         return $this;
     }
+
+    /**
+     * Enable requests limiter
+     */
+    public function enableLimiter()
+    {
+        Request::setLimiter(true);
+
+        return $this;
+    }
 }

--- a/structure.sql
+++ b/structure.sql
@@ -211,3 +211,15 @@ CREATE TABLE IF NOT EXISTS `botan_shortener` (
 
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+CREATE TABLE IF NOT EXISTS `request_limiter` (
+  `id` bigint UNSIGNED AUTO_INCREMENT COMMENT 'Unique identifier for this entry',
+  `chat_id` bigint NULL DEFAULT NULL COMMENT 'Unique chat identifier',
+  `inline_message_id` char(255) NULL DEFAULT NULL COMMENT 'Identifier of the sent inline message',
+  `method` char(255) DEFAULT NULL COMMENT 'Request method',
+  `created_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date creation',
+
+  PRIMARY KEY (`id`),
+  
+  FOREIGN KEY (`chat_id`) REFERENCES `chat` (`id`)
+) ENGINE=InnoDB DEFAULT charSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;

--- a/structure.sql
+++ b/structure.sql
@@ -214,12 +214,10 @@ CREATE TABLE IF NOT EXISTS `botan_shortener` (
 
 CREATE TABLE IF NOT EXISTS `request_limiter` (
   `id` bigint UNSIGNED AUTO_INCREMENT COMMENT 'Unique identifier for this entry',
-  `chat_id` bigint NULL DEFAULT NULL COMMENT 'Unique chat identifier',
+  `chat_id` char(255) NULL DEFAULT NULL COMMENT 'Unique chat identifier',
   `inline_message_id` char(255) NULL DEFAULT NULL COMMENT 'Identifier of the sent inline message',
   `method` char(255) DEFAULT NULL COMMENT 'Request method',
   `created_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date creation',
 
-  PRIMARY KEY (`id`),
-  
-  FOREIGN KEY (`chat_id`) REFERENCES `chat` (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT charSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;


### PR DESCRIPTION
#157

So, I've been using this implementation for a while now and I don't see any issues so far, neither any exceptions about Telegram returning response that I've hit the limit.  

By default disabled because it can be heavy on the database. 
Will delay requests using `sleep(1);`.

As mentioned in https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
- No more than 1 message / second (chat)
- No more than 30 messages / second (globally)
- No more than 20 messages / minute (groups and channels)

This also applies to message editing! Does not apply to methods like getChat or sendChatAction.

Currently I also included 'retry' mode, sometimes if the bot is heavily used 60 seconds wait might not be enough... should I remove this and simply give it only 60 seconds, no more? Or leave it as is?

**Will appreciate anyone to take a look at this!
Suggestions are welcome!**
