### PR TITLE
Fix #421 (Infinity loop after forwarding message from channel)

### DIFF
--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -55,7 +55,7 @@ class Message extends Entity
             'from'              => User::class,
             'chat'              => Chat::class,
             'forward_from'      => User::class,
-            'forward_from_chat' => User::class,
+            'forward_from_chat' => Chat::class,
             'reply_to_message'  => self::class,
             'entities'          => MessageEntity::class,
             'audio'             => Audio::class,


### PR DESCRIPTION
Small fix of copy/paste mistake. Just set right class (is must be Chat, but it was User) to forward_from_chat field for class Message.