### PR TITLE
add functionality to allow hiding commands in /help command

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -60,6 +60,13 @@ abstract class Command
     protected $usage = 'Command usage';
 
     /**
+     * Show in Help
+     *
+     * @var bool
+     */
+     protected $showInHelp = true;
+
+    /**
      * Version
      *
      * @var string
@@ -251,6 +258,16 @@ abstract class Command
     {
         return $this->name;
     }
+
+    /*
+     * Get Show in Help
+     *
+     * @return bool
+     */
+     public function getShowInHelp()
+     {
+     	return $this->showInHelp;
+     }
 
     /**
      * Check if command is enabled

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -64,7 +64,7 @@ abstract class Command
      *
      * @var bool
      */
-     protected $show_in_help = true;
+    protected $show_in_help = true;
 
     /**
      * Version
@@ -264,10 +264,10 @@ abstract class Command
      *
      * @return bool
      */
-     public function showInHelp()
-     {
+    public function showInHelp()
+    {
         return $this->show_in_help;
-     }
+    }
 
     /**
      * Check if command is enabled

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -259,7 +259,7 @@ abstract class Command
         return $this->name;
     }
 
-    /*
+    /**
      * Get Show in Help
      *
      * @return bool

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -266,7 +266,7 @@ abstract class Command
      */
      public function showInHelp()
      {
-     	return $this->show_in_help;
+        return $this->show_in_help;
      }
 
     /**

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -64,7 +64,7 @@ abstract class Command
      *
      * @var bool
      */
-     protected $showInHelp = true;
+     protected $show_in_help = true;
 
     /**
      * Version
@@ -264,9 +264,9 @@ abstract class Command
      *
      * @return bool
      */
-     public function getShowInHelp()
+     public function showInHelp()
      {
-     	return $this->showInHelp;
+     	return $this->show_in_help;
      }
 
     /**

--- a/src/Commands/UserCommands/HelpCommand.php
+++ b/src/Commands/UserCommands/HelpCommand.php
@@ -78,7 +78,6 @@ class HelpCommand extends UserCommand
                     $command->getName(),
                     $command->getDescription()
                 );
-
             }
 
             $text .= PHP_EOL . 'For exact command help type: /help <command>';

--- a/src/Commands/UserCommands/HelpCommand.php
+++ b/src/Commands/UserCommands/HelpCommand.php
@@ -69,7 +69,7 @@ class HelpCommand extends UserCommand
             );
 
             foreach ($command_objs as $command) {
-                if ($command->showInHelp()) {
+                if (!$command->showInHelp()) {
                     continue;
                 }
 

--- a/src/Commands/UserCommands/HelpCommand.php
+++ b/src/Commands/UserCommands/HelpCommand.php
@@ -69,11 +69,13 @@ class HelpCommand extends UserCommand
             );
 
             foreach ($command_objs as $command) {
-                $text .= sprintf(
-                    '/%s - %s' . PHP_EOL,
-                    $command->getName(),
-                    $command->getDescription()
-                );
+		if($command->getShowInHelp()) {
+               		$text .= sprintf(
+	                    '/%s - %s' . PHP_EOL,
+        	            $command->getName(),
+                	    $command->getDescription()
+               		 );
+		}
             }
 
             $text .= PHP_EOL . 'For exact command help type: /help <command>';

--- a/src/Commands/UserCommands/HelpCommand.php
+++ b/src/Commands/UserCommands/HelpCommand.php
@@ -69,13 +69,16 @@ class HelpCommand extends UserCommand
             );
 
             foreach ($command_objs as $command) {
-                if($command->getShowInHelp()) {
-                    $text .= sprintf(
-                    '/%s - %s' . PHP_EOL,
-                    $command->getName(),
-                    $command->getDescription()
-                    );
+                if($command->showInHelp()) {
+                    continue;
                 }
+
+                $text .= sprintf(
+                '/%s - %s' . PHP_EOL,
+                $command->getName(),
+                $command->getDescription()
+                );
+
             }
 
             $text .= PHP_EOL . 'For exact command help type: /help <command>';

--- a/src/Commands/UserCommands/HelpCommand.php
+++ b/src/Commands/UserCommands/HelpCommand.php
@@ -69,13 +69,13 @@ class HelpCommand extends UserCommand
             );
 
             foreach ($command_objs as $command) {
-		if($command->getShowInHelp()) {
-               		$text .= sprintf(
-	                    '/%s - %s' . PHP_EOL,
-        	            $command->getName(),
-                	    $command->getDescription()
-               		 );
-		}
+                if($command->getShowInHelp()) {
+                    $text .= sprintf(
+                    '/%s - %s' . PHP_EOL,
+                    $command->getName(),
+                    $command->getDescription()
+                    );
+                }
             }
 
             $text .= PHP_EOL . 'For exact command help type: /help <command>';

--- a/src/Commands/UserCommands/HelpCommand.php
+++ b/src/Commands/UserCommands/HelpCommand.php
@@ -69,14 +69,14 @@ class HelpCommand extends UserCommand
             );
 
             foreach ($command_objs as $command) {
-                if($command->showInHelp()) {
+                if ($command->showInHelp()) {
                     continue;
                 }
 
                 $text .= sprintf(
-                '/%s - %s' . PHP_EOL,
-                $command->getName(),
-                $command->getDescription()
+                    '/%s - %s' . PHP_EOL,
+                    $command->getName(),
+                    $command->getDescription()
                 );
 
             }

--- a/tests/unit/Commands/CommandTest.php
+++ b/tests/unit/Commands/CommandTest.php
@@ -127,6 +127,12 @@ class CommandTest extends TestCase
         $this->assertTrue($this->command_stub->isEnabled());
     }
 
+    public function testDefaultCommandShownInHelp()
+    {
+        $this->assertAttributeEquals(true, 'show_in_help', $this->command_stub);
+        $this->assertTrue($this->command_stub->showInHelp());
+    }
+
     public function testDefaultCommandNeedsMysql()
     {
         $this->assertAttributeEquals(false, 'need_mysql', $this->command_stub);

--- a/tests/unit/Commands/CommandTestCase.php
+++ b/tests/unit/Commands/CommandTestCase.php
@@ -39,6 +39,9 @@ class CommandTestCase extends TestCase
     {
         $this->telegram = new Telegram('apikey', 'testbot');
         $this->telegram->addCommandsPath(BASE_COMMANDS_PATH . '/UserCommands');
+
+        // Add custom commands dedicated to do some tests.
+        $this->telegram->addCommandsPath(__DIR__ . '/CustomTestCommands');
         $this->telegram->getCommandsList();
     }
 

--- a/tests/unit/Commands/CustomTestCommands/HiddenCommand.php
+++ b/tests/unit/Commands/CustomTestCommands/HiddenCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\UserCommands;
+
+use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Request;
+
+/**
+ * Test "/hidden" command to test $show_in_help
+ */
+class HiddenCommand extends UserCommand
+{
+    /**
+     * @var string
+     */
+    protected $name = 'hidden';
+
+    /**
+     * @var string
+     */
+    protected $description = 'This command is hidden in help';
+
+    /**
+     * @var string
+     */
+    protected $usage = '/hidden';
+
+    /**
+     * @var string
+     */
+    protected $version = '1.0.0';
+
+    /**
+     * @var bool
+     */
+    protected $show_in_help = false;
+
+    /**
+     * Command execute method
+     *
+     * @return mixed
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public function execute()
+    {
+        return Request::emptyResponse();
+    }
+}

--- a/tests/unit/Commands/CustomTestCommands/VisibleCommand.php
+++ b/tests/unit/Commands/CustomTestCommands/VisibleCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Commands\UserCommands;
+
+use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Request;
+
+/**
+ * Test "/visible" command to test $show_in_help
+ */
+class VisibleCommand extends UserCommand
+{
+    /**
+     * @var string
+     */
+    protected $name = 'visible';
+
+    /**
+     * @var string
+     */
+    protected $description = 'This command is visible in help';
+
+    /**
+     * @var string
+     */
+    protected $usage = '/visible';
+
+    /**
+     * @var string
+     */
+    protected $version = '1.0.0';
+
+    /**
+     * @var bool
+     */
+    protected $show_in_help = true;
+
+    /**
+     * Command execute method
+     *
+     * @return mixed
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public function execute()
+    {
+        return Request::emptyResponse();
+    }
+}

--- a/tests/unit/Commands/UserCommands/HelpCommandTest.php
+++ b/tests/unit/Commands/UserCommands/HelpCommandTest.php
@@ -10,9 +10,9 @@
 
 namespace Longman\TelegramBot\Tests\Unit\Commands\UserCommands;
 
+use Longman\TelegramBot\Commands\UserCommands\HelpCommand;
 use Longman\TelegramBot\Tests\Unit\Commands\CommandTestCase;
 use Longman\TelegramBot\Tests\Unit\TestHelpers;
-use Longman\TelegramBot\Commands\UserCommands\HelpCommand;
 
 /**
  * @package         TelegramTest
@@ -70,5 +70,16 @@ class HelpCommandTest extends CommandTestCase
             ->getResult()
             ->getText();
         $this->assertContains("Description: Show text\nUsage: /echo <text>", $text);
+    }
+
+    public function testHelpCommandWithHiddenCommand()
+    {
+        $text = $this->command
+            ->setUpdate(TestHelpers::getFakeUpdateCommandObject('/help'))
+            ->execute()
+            ->getResult()
+            ->getText();
+        $this->assertContains('/visible', $text);
+        $this->assertNotContains('/hidden', $text);
     }
 }


### PR DESCRIPTION
add `protected $showInHelp` var to `Command.php`

add `public function getShowInHelp()` to `Command.php`

add  `if($command->getShowInHelp()) {}` to wrap single command output at `HelpCommand.php`

with `protected $showInHelp = false;` insert into the command,it is not listed with /help command.

I find this very useful, cause i have some commands i only use over cronjob and don't want this commands to show up at the help command.
