### PR TITLE
Inline keyboard pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [0.41.0] - 2017-03-25
 ### Added
-- `$showInHelp` attribute for commands, to set if it should be displayed in the `/help` command.
+- `$show_in_help` attribute for commands, to set if it should be displayed in the `/help` command.
 - Link to new Telegram group: `https://telegram.me/PHP_Telegram_Bot_Support`
 - Introduce change log.
 

--- a/src/Entities/InlineKeyboard.php
+++ b/src/Entities/InlineKeyboard.php
@@ -21,7 +21,7 @@ class InlineKeyboard extends Keyboard
      * Get an inline pagination keyboard.
      *
      * - $callback_data is an ID for the CallbackqueryCommand, to know where the request comes from.
-     * It must contain a '%d' placeholder for the page number. If no placeholder is found, the ID is automatically appended with '_page_%d'
+     * The ID is automatically appended with '_page_%d' to filter out the selected page number.
      *
      * - $labels allows for custom button labels, using '%d' placeholders.
      * Default:
@@ -46,9 +46,7 @@ class InlineKeyboard extends Keyboard
      */
     public static function getPagination($callback_data, $current_page, $max_pages, array $labels = [])
     {
-        if (strpos($callback_data, '%d') === false) {
-            $callback_data .= '_page_%d';
-        }
+        $callback_data .= '_page_%d';
 
         // Merge labels with defaults.
         $labels = array_merge([
@@ -98,5 +96,17 @@ class InlineKeyboard extends Keyboard
         }
 
         return new InlineKeyboard($buttons);
+    }
+
+    /**
+     * Extract the page number from the passed callback data.
+     *
+     * @param string $callback_data
+     *
+     * @return int
+     */
+    public static function getPageFromCallbackData($callback_data)
+    {
+        return (int) preg_replace('/.*_page_(\d+)$/', '$1', $callback_data);
     }
 }

--- a/src/Entities/InlineKeyboard.php
+++ b/src/Entities/InlineKeyboard.php
@@ -17,4 +17,86 @@ namespace Longman\TelegramBot\Entities;
  */
 class InlineKeyboard extends Keyboard
 {
+    /**
+     * Get an inline pagination keyboard.
+     *
+     * - $callback_data is an ID for the CallbackqueryCommand, to know where the request comes from.
+     * It must contain a '%d' placeholder for the page number. If no placeholder is found, the ID is automatically appended with '_page_%d'
+     *
+     * - $labels allows for custom button labels, using '%d' placeholders.
+     * Default:
+     * ```
+     * [
+     *     'first'    => '« %d',
+     *     'previous' => '‹ %d',
+     *     'current'  => '· %d ·',
+     *     'next'     => '%d ›',
+     *     'last'     => '%d »',
+     * ]
+     * ``
+     *`
+     * initial idea from: https://stackoverflow.com/a/42879866
+     *
+     * @param string $callback_data
+     * @param int    $current_page
+     * @param int    $max_pages
+     * @param array  $labels
+     *
+     * @return \Longman\TelegramBot\Entities\InlineKeyboard
+     */
+    public static function getPagination($callback_data, $current_page, $max_pages, array $labels = [])
+    {
+        if (strpos($callback_data, '%d') === false) {
+            $callback_data .= '_page_%d';
+        }
+
+        // Merge labels with defaults.
+        $labels = array_merge([
+            'first'    => '« %d',
+            'previous' => '‹ %d',
+            'current'  => '· %d ·',
+            'next'     => '%d ›',
+            'last'     => '%d »',
+        ], $labels);
+        $pages  = [
+            'first'    => 1,
+            'previous' => $current_page - 1,
+            'current'  => $current_page,
+            'next'     => $current_page + 1,
+            'last'     => $max_pages,
+        ];
+
+        // Set labels for keyboard, replacing placeholders with page numbers.
+        foreach ($labels as $key => &$label) {
+            if (strpos($label, '%d') !== false) {
+                $label = sprintf($label, $pages[$key]);
+            }
+        }
+        unset($label);
+
+        $callbacks_data = [];
+        foreach ($pages as $key => $page) {
+            $callbacks_data[$key] = sprintf($callback_data, $page);
+        }
+
+        $buttons = [];
+
+        if ($current_page > 1) {
+            $buttons[] = new InlineKeyboardButton(['text' => $labels['first'], 'callback_data' => $callbacks_data['first']]);
+        }
+        if ($current_page > 2) {
+            $buttons[] = new InlineKeyboardButton(['text' => $labels['previous'], 'callback_data' => $callbacks_data['previous']]);
+        }
+
+        $buttons[] = new InlineKeyboardButton(['text' => $labels['current'], 'callback_data' => $callbacks_data['current']]);
+
+        if ($current_page < $max_pages - 1) {
+            $buttons[] = new InlineKeyboardButton(['text' => $labels['next'], 'callback_data' => $callbacks_data['next']]);
+        }
+        if ($current_page < $max_pages) {
+            $buttons[] = new InlineKeyboardButton(['text' => $labels['last'], 'callback_data' => $callbacks_data['last']]);
+        }
+
+        return new InlineKeyboard($buttons);
+    }
 }

--- a/src/Entities/InlineKeyboard.php
+++ b/src/Entities/InlineKeyboard.php
@@ -68,6 +68,8 @@ class InlineKeyboard extends Keyboard
         foreach ($labels as $key => &$label) {
             if (strpos($label, '%d') !== false) {
                 $label = sprintf($label, $pages[$key]);
+            } elseif ($label === '') {
+                $label = null;
             }
         }
         unset($label);
@@ -79,19 +81,21 @@ class InlineKeyboard extends Keyboard
 
         $buttons = [];
 
-        if ($current_page > 1) {
+        if ($current_page > 1 && $labels['first'] !== null) {
             $buttons[] = new InlineKeyboardButton(['text' => $labels['first'], 'callback_data' => $callbacks_data['first']]);
         }
-        if ($current_page > 2) {
+        if ($current_page > 2 && $labels['previous'] !== null) {
             $buttons[] = new InlineKeyboardButton(['text' => $labels['previous'], 'callback_data' => $callbacks_data['previous']]);
         }
 
-        $buttons[] = new InlineKeyboardButton(['text' => $labels['current'], 'callback_data' => $callbacks_data['current']]);
+        if ($labels['current'] !== null) {
+            $buttons[] = new InlineKeyboardButton(['text' => $labels['current'], 'callback_data' => $callbacks_data['current']]);
+        }
 
-        if ($current_page < $max_pages - 1) {
+        if ($current_page < $max_pages - 1 && $labels['next'] !== null) {
             $buttons[] = new InlineKeyboardButton(['text' => $labels['next'], 'callback_data' => $callbacks_data['next']]);
         }
-        if ($current_page < $max_pages) {
+        if ($current_page < $max_pages && $labels['last'] !== null) {
             $buttons[] = new InlineKeyboardButton(['text' => $labels['last'], 'callback_data' => $callbacks_data['last']]);
         }
 

--- a/src/Entities/InlineKeyboardPaginator.php
+++ b/src/Entities/InlineKeyboardPaginator.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Entities;
+
+interface InlineKeyboardPaginator
+{
+    /**
+     * A unique identifier for the callback query.
+     *
+     * @return string
+     */
+    public static function getCallbackDataId();
+
+    /**
+     * Get the output for the currently selected page.
+     *
+     * @param int $current_page
+     *
+     * @return string
+     */
+    public static function getOutput($current_page);
+
+    /**
+     * Get the pagination for the current page.
+     *
+     * @param int $current_page
+     *
+     * @return InlineKeyboard
+     */
+    public static function getPagination($current_page);
+}

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -373,7 +373,7 @@ class Telegram
      *
      * @return string
      */
-    private function getCommandFromType($type)
+    protected function getCommandFromType($type)
     {
         return $this->ucfirstUnicode(str_replace('_', '', $type));
     }

--- a/tests/unit/Entities/InlineKeyboardTest.php
+++ b/tests/unit/Entities/InlineKeyboardTest.php
@@ -200,20 +200,20 @@ class InlineKeyboardTest extends TestCase
             ['cbdata_page_1', 'cbdata_page_9', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
 
-        // custom labels
+        // custom labels, skipping some buttons
         // first, previous, current, next, last
         $keyboard = InlineKeyboard::getPagination($callback_data, 5, 10, [
-            'first'    => 'first %d',
+            'first'    => '',
             'previous' => 'previous %d',
-            'current'  => 'cur %d rent',
+            'current'  => null,
             'next'     => '%d next',
             'last'     => '%d last',
         ]);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['first 1', 'previous 4', 'cur 5 rent', '6 next', '10 last'],
+            ['previous 4', '6 next', '10 last'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['cbdata_page_1', 'cbdata_page_4', 'cbdata_page_5', 'cbdata_page_6', 'cbdata_page_10'],
+            ['cbdata_page_4', 'cbdata_page_6', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
     }
 }

--- a/tests/unit/Entities/InlineKeyboardTest.php
+++ b/tests/unit/Entities/InlineKeyboardTest.php
@@ -153,7 +153,7 @@ class InlineKeyboardTest extends TestCase
     public function testInlineKeyboardPagination()
     {
         // Should get '_page_%d' appended to it.
-        $callback_data = 'pagination_callback';
+        $callback_data = 'cbdata';
 
         // current
         $keyboard = InlineKeyboard::getPagination($callback_data, 1, 1);
@@ -161,11 +161,8 @@ class InlineKeyboardTest extends TestCase
             ['· 1 ·'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['pagination_callback_page_1'],
+            ['cbdata_page_1'],
         ], 'callback_data', $keyboard);
-
-        // Shorter custom callback data.
-        $callback_data = 'p%d';
 
         // current, next, last
         $keyboard = InlineKeyboard::getPagination($callback_data, 1, 10);
@@ -173,7 +170,7 @@ class InlineKeyboardTest extends TestCase
             ['· 1 ·', '2 ›', '10 »'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['p1', 'p2', 'p10'],
+            ['cbdata_page_1', 'cbdata_page_2', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
 
         // first, previous, current, next, last
@@ -182,7 +179,7 @@ class InlineKeyboardTest extends TestCase
             ['« 1', '‹ 4', '· 5 ·', '6 ›', '10 »'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['p1', 'p4', 'p5', 'p6', 'p10'],
+            ['cbdata_page_1', 'cbdata_page_4', 'cbdata_page_5', 'cbdata_page_6', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
 
         // first, previous, current, last
@@ -191,7 +188,7 @@ class InlineKeyboardTest extends TestCase
             ['« 1', '‹ 8', '· 9 ·', '10 »'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['p1', 'p8', 'p9', 'p10'],
+            ['cbdata_page_1', 'cbdata_page_8', 'cbdata_page_9', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
 
         // first, previous, current
@@ -200,7 +197,7 @@ class InlineKeyboardTest extends TestCase
             ['« 1', '‹ 9', '· 10 ·'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['p1', 'p9', 'p10'],
+            ['cbdata_page_1', 'cbdata_page_9', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
 
         // custom labels
@@ -216,7 +213,7 @@ class InlineKeyboardTest extends TestCase
             ['first 1', 'previous 4', 'cur 5 rent', '6 next', '10 last'],
         ], 'text', $keyboard);
         KeyboardTest::assertAllButtonPropertiesEqual([
-            ['p1', 'p4', 'p5', 'p6', 'p10'],
+            ['cbdata_page_1', 'cbdata_page_4', 'cbdata_page_5', 'cbdata_page_6', 'cbdata_page_10'],
         ], 'callback_data', $keyboard);
     }
 }

--- a/tests/unit/Entities/InlineKeyboardTest.php
+++ b/tests/unit/Entities/InlineKeyboardTest.php
@@ -54,51 +54,60 @@ class InlineKeyboardTest extends TestCase
 
     public function testInlineKeyboardSingleButtonSingleRow()
     {
-        $inline_keyboard = (new InlineKeyboard(
+        $keyboard = new InlineKeyboard(
             $this->getRandomButton('Button Text 1')
-        ))->getProperty('inline_keyboard');
-        self::assertSame('Button Text 1', $inline_keyboard[0][0]->getText());
+        );
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+        ], 'text', $keyboard);
 
-        $inline_keyboard = (new InlineKeyboard(
+        $keyboard = new InlineKeyboard(
             [$this->getRandomButton('Button Text 2')]
-        ))->getProperty('inline_keyboard');
-        self::assertSame('Button Text 2', $inline_keyboard[0][0]->getText());
+        );
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 2'],
+        ], 'text', $keyboard);
     }
 
     public function testInlineKeyboardSingleButtonMultipleRows()
     {
-        $keyboard = (new InlineKeyboard(
+        $keyboard = new InlineKeyboard(
             $this->getRandomButton('Button Text 1'),
             $this->getRandomButton('Button Text 2'),
             $this->getRandomButton('Button Text 3')
-        ))->getProperty('inline_keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 2', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 3', $keyboard[2][0]->getText());
+        );
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+            ['Button Text 2'],
+            ['Button Text 3'],
+        ], 'text', $keyboard);
 
-        $keyboard = (new InlineKeyboard(
+        $keyboard = new InlineKeyboard(
             [$this->getRandomButton('Button Text 4')],
             [$this->getRandomButton('Button Text 5')],
             [$this->getRandomButton('Button Text 6')]
-        ))->getProperty('inline_keyboard');
-        self::assertSame('Button Text 4', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 5', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 6', $keyboard[2][0]->getText());
+        );
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 4'],
+            ['Button Text 5'],
+            ['Button Text 6'],
+        ], 'text', $keyboard);
     }
 
     public function testInlineKeyboardMultipleButtonsSingleRow()
     {
-        $keyboard = (new InlineKeyboard([
+        $keyboard = new InlineKeyboard([
             $this->getRandomButton('Button Text 1'),
             $this->getRandomButton('Button Text 2'),
-        ]))->getProperty('inline_keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 2', $keyboard[0][1]->getText());
+        ]);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1', 'Button Text 2'],
+        ], 'text', $keyboard);
     }
 
     public function testInlineKeyboardMultipleButtonsMultipleRows()
     {
-        $keyboard = (new InlineKeyboard(
+        $keyboard = new InlineKeyboard(
             [
                 $this->getRandomButton('Button Text 1'),
                 $this->getRandomButton('Button Text 2'),
@@ -107,32 +116,107 @@ class InlineKeyboardTest extends TestCase
                 $this->getRandomButton('Button Text 3'),
                 $this->getRandomButton('Button Text 4'),
             ]
-        ))->getProperty('inline_keyboard');
+        );
 
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 2', $keyboard[0][1]->getText());
-        self::assertSame('Button Text 3', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 4', $keyboard[1][1]->getText());
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1', 'Button Text 2'],
+            ['Button Text 3', 'Button Text 4'],
+        ], 'text', $keyboard);
     }
 
     public function testInlineKeyboardAddRows()
     {
-        $keyboard_obj = new InlineKeyboard([]);
+        $keyboard = new InlineKeyboard([]);
 
-        $keyboard_obj->addRow($this->getRandomButton('Button Text 1'));
-        $keyboard = $keyboard_obj->getProperty('inline_keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
+        $keyboard->addRow($this->getRandomButton('Button Text 1'));
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+        ], 'text', $keyboard);
 
-        $keyboard_obj->addRow(
+        $keyboard->addRow(
             $this->getRandomButton('Button Text 2'),
             $this->getRandomButton('Button Text 3')
         );
-        $keyboard = $keyboard_obj->getProperty('inline_keyboard');
-        self::assertSame('Button Text 2', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 3', $keyboard[1][1]->getText());
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+            ['Button Text 2', 'Button Text 3'],
+        ], 'text', $keyboard);
 
-        $keyboard_obj->addRow($this->getRandomButton('Button Text 4'));
-        $keyboard = $keyboard_obj->getProperty('inline_keyboard');
-        self::assertSame('Button Text 4', $keyboard[2][0]->getText());
+        $keyboard->addRow($this->getRandomButton('Button Text 4'));
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+            ['Button Text 2', 'Button Text 3'],
+            ['Button Text 4'],
+        ], 'text', $keyboard);
+    }
+
+    public function testInlineKeyboardPagination()
+    {
+        // Should get '_page_%d' appended to it.
+        $callback_data = 'pagination_callback';
+
+        // current
+        $keyboard = InlineKeyboard::getPagination($callback_data, 1, 1);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['· 1 ·'],
+        ], 'text', $keyboard);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['pagination_callback_page_1'],
+        ], 'callback_data', $keyboard);
+
+        // Shorter custom callback data.
+        $callback_data = 'p%d';
+
+        // current, next, last
+        $keyboard = InlineKeyboard::getPagination($callback_data, 1, 10);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['· 1 ·', '2 ›', '10 »'],
+        ], 'text', $keyboard);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['p1', 'p2', 'p10'],
+        ], 'callback_data', $keyboard);
+
+        // first, previous, current, next, last
+        $keyboard = InlineKeyboard::getPagination($callback_data, 5, 10);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['« 1', '‹ 4', '· 5 ·', '6 ›', '10 »'],
+        ], 'text', $keyboard);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['p1', 'p4', 'p5', 'p6', 'p10'],
+        ], 'callback_data', $keyboard);
+
+        // first, previous, current, last
+        $keyboard = InlineKeyboard::getPagination($callback_data, 9, 10);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['« 1', '‹ 8', '· 9 ·', '10 »'],
+        ], 'text', $keyboard);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['p1', 'p8', 'p9', 'p10'],
+        ], 'callback_data', $keyboard);
+
+        // first, previous, current
+        $keyboard = InlineKeyboard::getPagination($callback_data, 10, 10);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['« 1', '‹ 9', '· 10 ·'],
+        ], 'text', $keyboard);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['p1', 'p9', 'p10'],
+        ], 'callback_data', $keyboard);
+
+        // custom labels
+        // first, previous, current, next, last
+        $keyboard = InlineKeyboard::getPagination($callback_data, 5, 10, [
+            'first'    => 'first %d',
+            'previous' => 'previous %d',
+            'current'  => 'cur %d rent',
+            'next'     => '%d next',
+            'last'     => '%d last',
+        ]);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['first 1', 'previous 4', 'cur 5 rent', '6 next', '10 last'],
+        ], 'text', $keyboard);
+        KeyboardTest::assertAllButtonPropertiesEqual([
+            ['p1', 'p4', 'p5', 'p6', 'p10'],
+        ], 'callback_data', $keyboard);
     }
 }

--- a/tests/unit/Entities/KeyboardTest.php
+++ b/tests/unit/Entities/KeyboardTest.php
@@ -22,6 +22,27 @@ use Longman\TelegramBot\Entities\KeyboardButton;
  */
 class KeyboardTest extends TestCase
 {
+    public static function assertButtonPropertiesEqual($value, $property, $keyboard, $row, $column, $message = '')
+    {
+        self::assertSame($value, $keyboard->getProperty($keyboard->getKeyboardType())[$row][$column]->getProperty($property), $message);
+    }
+
+    public static function assertRowButtonPropertiesEqual(array $values, $property, $keyboard, $row, $message = '')
+    {
+        $column = 0;
+        foreach ($values as $value) {
+            self::assertButtonPropertiesEqual($value, $property, $keyboard, $row, $column++, $message);
+        }
+    }
+
+    public static function assertAllButtonPropertiesEqual(array $all_values, $property, $keyboard, $message = '')
+    {
+        $row = 0;
+        foreach ($all_values as $values) {
+            self::assertRowButtonPropertiesEqual($values, $property, $keyboard, $row++, $message);
+        }
+    }
+
     /**
      * @expectedException \Longman\TelegramBot\Exception\TelegramException
      * @expectedExceptionMessage keyboard field is not an array!
@@ -42,96 +63,109 @@ class KeyboardTest extends TestCase
 
     public function testKeyboardSingleButtonSingleRow()
     {
-        $keyboard = (new Keyboard('Button Text 1'))->getProperty('keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
+        $keyboard = new Keyboard('Button Text 1');
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+        ], 'text', $keyboard);
 
-        $keyboard = (new Keyboard(['Button Text 2']))->getProperty('keyboard');
-        self::assertSame('Button Text 2', $keyboard[0][0]->getText());
+        $keyboard = new Keyboard(['Button Text 2']);
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 2'],
+        ], 'text', $keyboard);
     }
 
     public function testKeyboardSingleButtonMultipleRows()
     {
-        $keyboard = (new Keyboard(
+        $keyboard = new Keyboard(
             'Button Text 1',
             'Button Text 2',
             'Button Text 3'
-        ))->getProperty('keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 2', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 3', $keyboard[2][0]->getText());
+        );
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+            ['Button Text 2'],
+            ['Button Text 3'],
+        ], 'text', $keyboard);
 
-        $keyboard = (new Keyboard(
+        $keyboard = new Keyboard(
             ['Button Text 4'],
             ['Button Text 5'],
             ['Button Text 6']
-        ))->getProperty('keyboard');
-        self::assertSame('Button Text 4', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 5', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 6', $keyboard[2][0]->getText());
+        );
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 4'],
+            ['Button Text 5'],
+            ['Button Text 6'],
+        ], 'text', $keyboard);
     }
 
     public function testKeyboardMultipleButtonsSingleRow()
     {
-        $keyboard = (new Keyboard(['Button Text 1', 'Button Text 2']))->getProperty('keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 2', $keyboard[0][1]->getText());
+        $keyboard = new Keyboard(['Button Text 1', 'Button Text 2']);
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1', 'Button Text 2'],
+        ], 'text', $keyboard);
     }
 
     public function testKeyboardMultipleButtonsMultipleRows()
     {
-        $keyboard = (new Keyboard(
+        $keyboard = new Keyboard(
             ['Button Text 1', 'Button Text 2'],
             ['Button Text 3', 'Button Text 4']
-        ))->getProperty('keyboard');
-
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 2', $keyboard[0][1]->getText());
-        self::assertSame('Button Text 3', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 4', $keyboard[1][1]->getText());
+        );
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1', 'Button Text 2'],
+            ['Button Text 3', 'Button Text 4'],
+        ], 'text', $keyboard);
     }
 
     public function testKeyboardWithButtonObjects()
     {
-        $keyboard = (new Keyboard(
+        $keyboard = new Keyboard(
             new KeyboardButton('Button Text 1')
-        ))->getProperty('keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
+        );
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+        ], 'text', $keyboard);
 
-        $keyboard = (new Keyboard(
+        $keyboard = new Keyboard(
             new KeyboardButton('Button Text 2'),
             new KeyboardButton('Button Text 3')
-        ))->getProperty('keyboard');
-        self::assertSame('Button Text 2', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 3', $keyboard[1][0]->getText());
+        );
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 2'],
+            ['Button Text 3'],
+        ], 'text', $keyboard);
 
-        $keyboard = (new Keyboard(
+        $keyboard = new Keyboard(
             [new KeyboardButton('Button Text 4')],
             [new KeyboardButton('Button Text 5'), new KeyboardButton('Button Text 6')]
-        ))->getProperty('keyboard');
-        self::assertSame('Button Text 4', $keyboard[0][0]->getText());
-        self::assertSame('Button Text 5', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 6', $keyboard[1][1]->getText());
+        );
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 4'],
+            ['Button Text 5', 'Button Text 6'],
+        ], 'text', $keyboard);
     }
 
     public function testKeyboardWithDataArray()
     {
-        $resize_keyboard   = (bool)mt_rand(0, 1);
-        $one_time_keyboard = (bool)mt_rand(0, 1);
-        $selective         = (bool)mt_rand(0, 1);
+        $resize_keyboard   = (bool) mt_rand(0, 1);
+        $one_time_keyboard = (bool) mt_rand(0, 1);
+        $selective         = (bool) mt_rand(0, 1);
 
-        $keyboard_obj = new Keyboard([
+        $keyboard = new Keyboard([
             'resize_keyboard'   => $resize_keyboard,
             'one_time_keyboard' => $one_time_keyboard,
             'selective'         => $selective,
             'keyboard'          => [['Button Text 1']],
         ]);
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+        ], 'text', $keyboard);
 
-        $keyboard = $keyboard_obj->getProperty('keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
-
-        self::assertSame($resize_keyboard, $keyboard_obj->getResizeKeyboard());
-        self::assertSame($one_time_keyboard, $keyboard_obj->getOneTimeKeyboard());
-        self::assertSame($selective, $keyboard_obj->getSelective());
+        self::assertSame($resize_keyboard, $keyboard->getResizeKeyboard());
+        self::assertSame($one_time_keyboard, $keyboard->getOneTimeKeyboard());
+        self::assertSame($selective, $keyboard->getSelective());
     }
 
     public function testPredefinedKeyboards()
@@ -145,43 +179,48 @@ class KeyboardTest extends TestCase
 
     public function testKeyboardMethods()
     {
-        $keyboard_obj = new Keyboard([]);
+        $keyboard = new Keyboard([]);
 
-        self::assertEmpty($keyboard_obj->getOneTimeKeyboard());
-        self::assertEmpty($keyboard_obj->getResizeKeyboard());
-        self::assertEmpty($keyboard_obj->getSelective());
+        self::assertEmpty($keyboard->getOneTimeKeyboard());
+        self::assertEmpty($keyboard->getResizeKeyboard());
+        self::assertEmpty($keyboard->getSelective());
 
-        $keyboard_obj->setOneTimeKeyboard(true);
-        self::assertTrue($keyboard_obj->getOneTimeKeyboard());
-        $keyboard_obj->setOneTimeKeyboard(false);
-        self::assertFalse($keyboard_obj->getOneTimeKeyboard());
+        $keyboard->setOneTimeKeyboard(true);
+        self::assertTrue($keyboard->getOneTimeKeyboard());
+        $keyboard->setOneTimeKeyboard(false);
+        self::assertFalse($keyboard->getOneTimeKeyboard());
 
-        $keyboard_obj->setResizeKeyboard(true);
-        self::assertTrue($keyboard_obj->getResizeKeyboard());
-        $keyboard_obj->setResizeKeyboard(false);
-        self::assertFalse($keyboard_obj->getResizeKeyboard());
+        $keyboard->setResizeKeyboard(true);
+        self::assertTrue($keyboard->getResizeKeyboard());
+        $keyboard->setResizeKeyboard(false);
+        self::assertFalse($keyboard->getResizeKeyboard());
 
-        $keyboard_obj->setSelective(true);
-        self::assertTrue($keyboard_obj->getSelective());
-        $keyboard_obj->setSelective(false);
-        self::assertFalse($keyboard_obj->getSelective());
+        $keyboard->setSelective(true);
+        self::assertTrue($keyboard->getSelective());
+        $keyboard->setSelective(false);
+        self::assertFalse($keyboard->getSelective());
     }
 
     public function testKeyboardAddRows()
     {
-        $keyboard_obj = new Keyboard([]);
+        $keyboard = new Keyboard([]);
 
-        $keyboard_obj->addRow('Button Text 1');
-        $keyboard = $keyboard_obj->getProperty('keyboard');
-        self::assertSame('Button Text 1', $keyboard[0][0]->getText());
+        $keyboard->addRow('Button Text 1');
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+        ], 'text', $keyboard);
 
-        $keyboard_obj->addRow('Button Text 2', 'Button Text 3');
-        $keyboard = $keyboard_obj->getProperty('keyboard');
-        self::assertSame('Button Text 2', $keyboard[1][0]->getText());
-        self::assertSame('Button Text 3', $keyboard[1][1]->getText());
+        $keyboard->addRow('Button Text 2', 'Button Text 3');
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+            ['Button Text 2', 'Button Text 3'],
+        ], 'text', $keyboard);
 
-        $keyboard_obj->addRow(['text' => 'Button Text 4']);
-        $keyboard = $keyboard_obj->getProperty('keyboard');
-        self::assertSame('Button Text 4', $keyboard[2][0]->getText());
+        $keyboard->addRow(['text' => 'Button Text 4']);
+        self::assertAllButtonPropertiesEqual([
+            ['Button Text 1'],
+            ['Button Text 2', 'Button Text 3'],
+            ['Button Text 4'],
+        ], 'text', $keyboard);
     }
 }


### PR DESCRIPTION
This PR offers a simple way to add an inline pagination keyboard.

![userlist](https://cloud.githubusercontent.com/assets/9423417/24315544/deba8c44-10e7-11e7-8665-b8c456373cff.png)

The idea has been around for a while and #436 gave me the kick to implement it.

**How it works**
Example command `/basicpages`
![basicpages](https://cloud.githubusercontent.com/assets/9423417/24315540/d9f14914-10e7-11e7-948c-b6a1d2daf55d.png)

`BasicpagesCommand.php`
In the command, implement the `InlineKeyboardPaginator`, populate the required static methods, set `reply_markup` to the paginator, done!
```php
<?php

namespace Longman\TelegramBot\Commands\UserCommands;

use Longman\TelegramBot\Commands\UserCommand;
use Longman\TelegramBot\Entities\InlineKeyboard;
use Longman\TelegramBot\Entities\InlineKeyboardPaginator;
use Longman\TelegramBot\Request;

class BasicpagesCommand extends UserCommand implements InlineKeyboardPaginator
{
    protected $name = 'basicpages';
    protected $description = 'Basic pages for inline keyboard pagination';
    protected $usage = '/basicpages';
    protected $version = '1.0.0';
    protected static $max_pages = 5; // Assigned dynamically in a real-life scenario!

    public static function getCallbackDataId()
    {
        return 'basicpages';
    }

    public static function getPagination($current_page)
    {
        return InlineKeyboard::getPagination(self::getCallbackDataId(), $current_page, self::$max_pages);
    }

    public static function getOutput($current_page)
    {
        return sprintf('Page %d of %d', $current_page, self::$max_pages);
    }

    public function execute()
    {
        // Using pagination
        $data = [
            'chat_id'      => $this->getMessage()->getChat()->getId(),
            'text'         => self::getOutput(1),
            'reply_markup' => self::getPagination(1),
        ];

        return Request::sendMessage($data);
    }
}
```

`CallbackqueryCommand.php`
In the callback query handler, we just need to get the current page number and can then edit the message to display the updated data.
```php
<?php

namespace Longman\TelegramBot\Commands\SystemCommands;

use Longman\TelegramBot\Commands\SystemCommand;
use Longman\TelegramBot\Commands\UserCommands\BasicpagesCommand;
use Longman\TelegramBot\Entities\InlineKeyboard;
use Longman\TelegramBot\Request;

class CallbackqueryCommand extends SystemCommand
{
    protected $name = 'callbackquery';
    protected $description = 'Reply to callback query';
    protected $version = '1.0.0';

    public function execute()
    {
        $callback_data = $this->getUpdate()->getCallbackQuery()->getData();

        if (strpos($callback_data, 'basicpages') === 0) {
            return $this->handleBasicPages();
        }

        return Request::emptyResponse();
    }

    protected function handleBasicPages()
    {
        $callback_query = $this->getUpdate()->getCallbackQuery();
        $callback_data  = $callback_query->getData();

        // Get the page from the callback_data.
        $current_page = InlineKeyboard::getPageFromCallbackData($callback_data);

        return Request::editMessageText([
            'chat_id'      => $callback_query->getMessage()->getChat()->getId(),
            'message_id'   => $callback_query->getMessage()->getMessageId(),
            'text'         => BasicpagesCommand::getOutput($current_page),
            'reply_markup' => BasicpagesCommand::getPagination($current_page),
        ]);
    }
}
```

**What would be nice to have changed to make this work even better**:
- Public static properties for commands, so that they can be accessed from everywhere, thus removing the requirement for `getCallbackDataId()`
- It would be brilliant to add some kind of `registerCallbackQueryHandler` method to the default system `CallbackqueryCommand` class. This could allow adding handlers without having to copy the command and adding it to a custom commands folder.

**Thoughts**:
The way it is now, when on the first or last page, only 3 buttons get displayed.
![first-page](https://cloud.githubusercontent.com/assets/9423417/24315653/849ea974-10e8-11e7-88bf-14553f8816d6.png)
Would it make sense to always display 5 if there are enough pages?
Also, what if there are 100 pages, should there be a second row of buttons for greater page jumps?
![big-keyboard](https://cloud.githubusercontent.com/assets/9423417/24315794/a6d64334-10e9-11e7-9a47-9ed5f71c3ecc.png)

**Your opinion!**
Please give this a try and give me your feedback!